### PR TITLE
Refactor pages to use a new sidebar layout

### DIFF
--- a/src/main/react/app/components/sidebars-layout/sidebar-close.tsx
+++ b/src/main/react/app/components/sidebars-layout/sidebar-close.tsx
@@ -1,5 +1,5 @@
 import SidebarIcon from '/icons/solar/Sidebar Minimalistic.svg?react'
-import { useSidebarStore, SidebarSide } from '~/components/sidebars-layout/sidebar-layout-store'
+import { SidebarSide, useSidebarStore } from '~/components/sidebars-layout/sidebar-layout-store'
 import clsx from 'clsx'
 import { useContext } from 'react'
 import { SidebarContext } from '~/components/sidebars-layout/sidebar-layout'
@@ -10,9 +10,10 @@ export interface SidebarsCloseProperties {
 
 export default function SidebarClose({ side }: Readonly<SidebarsCloseProperties>) {
   const layoutName = useContext(SidebarContext)
-  if (!layoutName) throw new Error('SidebarsClose must be used within a SidebarLayout or be provided a layoutName prop')
   const { toggleSidebar } = useSidebarStore()
   const isLeft = side === SidebarSide.LEFT
+
+  if (!layoutName) throw new Error('SidebarsClose must be used within a SidebarLayout or be provided a layoutName prop')
 
   const toggleVisible = () => {
     toggleSidebar(layoutName, side)

--- a/src/main/react/app/components/sidebars-layout/sidebar-close.tsx
+++ b/src/main/react/app/components/sidebars-layout/sidebar-close.tsx
@@ -10,12 +10,9 @@ export interface SidebarsCloseProperties {
 
 export default function SidebarClose({ side }: Readonly<SidebarsCloseProperties>) {
   const layoutName = useContext(SidebarContext)
+  if (!layoutName) throw new Error('SidebarsClose must be used within a SidebarLayout or be provided a layoutName prop')
   const { toggleSidebar } = useSidebarStore()
   const isLeft = side === SidebarSide.LEFT
-
-  if (!layoutName) {
-    throw new Error('SidebarsClose must be used within a SidebarLayout or be provided a layoutName prop')
-  }
 
   const toggleVisible = () => {
     toggleSidebar(layoutName, side)

--- a/src/main/react/app/components/sidebars-layout/sidebar-close.tsx
+++ b/src/main/react/app/components/sidebars-layout/sidebar-close.tsx
@@ -1,0 +1,30 @@
+import SidebarIcon from '/icons/solar/Sidebar Minimalistic.svg?react'
+import { useSidebarStore, SidebarSide } from '~/components/sidebars-layout/sidebar-layout-store'
+import clsx from 'clsx'
+import { useContext } from 'react'
+import { SidebarContext } from '~/components/sidebars-layout/sidebar-layout'
+
+export interface SidebarsCloseProperties {
+  side: SidebarSide
+}
+
+export default function SidebarClose({ side }: Readonly<SidebarsCloseProperties>) {
+  const layoutName = useContext(SidebarContext)
+  const { toggleSidebar } = useSidebarStore()
+  const isLeft = side === SidebarSide.LEFT
+
+  if (!layoutName) {
+    throw new Error('SidebarsClose must be used within a SidebarLayout or be provided a layoutName prop')
+  }
+
+  const toggleVisible = () => {
+    toggleSidebar(layoutName, side)
+  }
+
+  return (
+    <SidebarIcon
+      onClick={toggleVisible}
+      className={clsx('fill-gray-950 hover:fill-[var(--color-brand)]', isLeft && 'rotate-180')}
+    ></SidebarIcon>
+  )
+}

--- a/src/main/react/app/components/sidebars-layout/sidebar-content-close.tsx
+++ b/src/main/react/app/components/sidebars-layout/sidebar-content-close.tsx
@@ -5,11 +5,8 @@ import { SidebarContext } from '~/components/sidebars-layout/sidebar-layout'
 
 export default function SidebarContentClose(properties: Readonly<SidebarsCloseProperties>) {
   const layoutName = useContext(SidebarContext)
-  const visible = useSidebarStore((sate) => sate.instances[layoutName].visible[properties.side])
-
-  if (!layoutName) {
-    throw new Error('SidebarsClose must be used within a SidebarLayout or be provided a layoutName prop')
-  }
+  if (!layoutName) throw new Error('SidebarsClose must be used within a SidebarLayout or be provided a layoutName prop')
+  const visible = useSidebarStore((sate) => sate.instances[layoutName]?.visible[properties.side])
 
   if (!visible) {
     return (
@@ -18,4 +15,5 @@ export default function SidebarContentClose(properties: Readonly<SidebarsClosePr
       </div>
     )
   }
+  return null
 }

--- a/src/main/react/app/components/sidebars-layout/sidebar-content-close.tsx
+++ b/src/main/react/app/components/sidebars-layout/sidebar-content-close.tsx
@@ -6,7 +6,7 @@ import { SidebarContext } from '~/components/sidebars-layout/sidebar-layout'
 export default function SidebarContentClose(properties: Readonly<SidebarsCloseProperties>) {
   const layoutName = useContext(SidebarContext)
   if (!layoutName) throw new Error('SidebarsClose must be used within a SidebarLayout or be provided a layoutName prop')
-  const visible = useSidebarStore((sate) => sate.instances[layoutName]?.visible[properties.side])
+  const visible = useSidebarStore((sate) => sate.instances[layoutName].visible[properties.side])
 
   if (!visible) {
     return (

--- a/src/main/react/app/components/sidebars-layout/sidebar-content-close.tsx
+++ b/src/main/react/app/components/sidebars-layout/sidebar-content-close.tsx
@@ -1,0 +1,21 @@
+import SidebarClose, { type SidebarsCloseProperties } from '~/components/sidebars-layout/sidebar-close'
+import { useSidebarStore } from '~/components/sidebars-layout/sidebar-layout-store'
+import { useContext } from 'react'
+import { SidebarContext } from '~/components/sidebars-layout/sidebar-layout'
+
+export default function SidebarContentClose(properties: Readonly<SidebarsCloseProperties>) {
+  const layoutName = useContext(SidebarContext)
+  const visible = useSidebarStore((sate) => sate.instances[layoutName].visible[properties.side])
+
+  if (!layoutName) {
+    throw new Error('SidebarsClose must be used within a SidebarLayout or be provided a layoutName prop')
+  }
+
+  if (!visible) {
+    return (
+      <div className="flex aspect-square h-12 items-center justify-center border border-gray-200">
+        <SidebarClose {...properties} />
+      </div>
+    )
+  }
+}

--- a/src/main/react/app/components/sidebars-layout/sidebar-header.tsx
+++ b/src/main/react/app/components/sidebars-layout/sidebar-header.tsx
@@ -1,0 +1,14 @@
+import SidebarClose, { type SidebarsCloseProperties } from '~/components/sidebars-layout/sidebar-close'
+
+type SidebarsHeaderProperties = {
+  title?: string
+} & SidebarsCloseProperties
+
+export default function SidebarHeader({ title, side }: Readonly<SidebarsHeaderProperties>) {
+  return (
+    <div className="flex h-12 items-center gap-1 px-4">
+      <SidebarClose side={side} />
+      {title && <div className="text-xl">{title}</div>}
+    </div>
+  )
+}

--- a/src/main/react/app/components/sidebars-layout/sidebar-header.tsx
+++ b/src/main/react/app/components/sidebars-layout/sidebar-header.tsx
@@ -1,14 +1,19 @@
 import SidebarClose, { type SidebarsCloseProperties } from '~/components/sidebars-layout/sidebar-close'
+import { SidebarSide } from '~/components/sidebars-layout/sidebar-layout-store'
+import clsx from 'clsx'
 
 type SidebarsHeaderProperties = {
   title?: string
 } & SidebarsCloseProperties
 
 export default function SidebarHeader({ title, side }: Readonly<SidebarsHeaderProperties>) {
+  const isLeft = side === SidebarSide.LEFT
+
   return (
-    <div className="flex h-12 items-center gap-1 px-4">
-      <SidebarClose side={side} />
+    <div className={clsx('flex h-12 items-center px-4', isLeft ? 'gap-1' : 'justify-between')}>
+      {side === SidebarSide.LEFT && <SidebarClose side={side} />}
       {title && <div className="text-xl">{title}</div>}
+      {side === SidebarSide.RIGHT && <SidebarClose side={side} />}
     </div>
   )
 }

--- a/src/main/react/app/components/sidebars-layout/sidebar-layout-store.ts
+++ b/src/main/react/app/components/sidebars-layout/sidebar-layout-store.ts
@@ -1,0 +1,98 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+export enum SidebarSide {
+  LEFT = 0,
+  MIDDLE = 1,
+  RIGHT = 2,
+}
+
+export type VisibilityState = [boolean, boolean, boolean]
+
+interface SideBarInstance {
+  visible: VisibilityState
+  sizes: number[]
+}
+
+interface SidebarState {
+  instances: Record<string, SideBarInstance>
+
+  initializeInstance: (name: string, defaultVisible?: VisibilityState) => void
+  toggleSidebar: (name: string, side: SidebarSide) => void
+  setSizes: (name: string, sizes: number[]) => void
+  setVisible: (name: string, side: SidebarSide, value: boolean) => void
+}
+
+const DEFAULT_VISIBILITY: VisibilityState = [true, true, true]
+
+export const useSidebarStore = create<SidebarState>()(
+  persist(
+    (set) => ({
+      instances: {},
+
+      initializeInstance: (name, defaultVisible = DEFAULT_VISIBILITY) =>
+        set((state) => {
+          if (state.instances[name]) return state
+
+          return {
+            instances: {
+              ...state.instances,
+              [name]: {
+                visible: defaultVisible,
+                sizes: [],
+              },
+            },
+          }
+        }),
+
+      toggleSidebar: (name, side) =>
+        set((state) => {
+          const instance = state.instances[name]
+          if (!instance) return state
+
+          const newVisible: VisibilityState = [...instance.visible]
+          newVisible[side] = !newVisible[side]
+
+          return updateInstanceState(state, name, { visible: newVisible })
+        }),
+
+      setSizes: (name, sizes) =>
+        set((state) => {
+          const instance = state.instances[name]
+          if (!instance) return state
+
+          return updateInstanceState(state, name, { sizes })
+        }),
+
+      setVisible: (name, side, value) =>
+        set((state) => {
+          const instance = state.instances[name]
+          if (!instance) return state
+
+          const newVisible: VisibilityState = [...instance.visible]
+          newVisible[side] = value
+
+          return updateInstanceState(state, name, { visible: newVisible })
+        }),
+    }),
+    {
+      name: 'sidebar-storage',
+    },
+  ),
+)
+
+function updateInstanceState(
+  state: SidebarState,
+  name: string,
+  updates: Partial<SideBarInstance>,
+): Partial<SidebarState> {
+  return {
+    instances: {
+      ...state.instances,
+      [name]: {
+        ...state.instances[name],
+        ...updates,
+      },
+    },
+  }
+}

--- a/src/main/react/app/components/sidebars-layout/sidebar-layout.tsx
+++ b/src/main/react/app/components/sidebars-layout/sidebar-layout.tsx
@@ -1,0 +1,74 @@
+import React, { createContext, useEffect } from 'react'
+import { Allotment } from 'allotment'
+import { SidebarSide, useSidebarStore, type VisibilityState } from '~/components/sidebars-layout/sidebar-layout-store'
+
+export const SidebarContext = createContext<string | undefined>(undefined)
+
+interface SidebarLayoutProperties {
+  children: React.ReactNode
+  name: string
+  defaultVisible?: VisibilityState
+  windowResizeOnChange?: boolean
+}
+
+export default function SidebarLayout({
+  children,
+  name,
+  defaultVisible,
+  windowResizeOnChange,
+}: Readonly<SidebarLayoutProperties>) {
+  const { initializeInstance, setSizes, setVisible } = useSidebarStore()
+  const sizes = useSidebarStore((state) => state.instances[name]?.sizes) || []
+  const visible = useSidebarStore((state) => state.instances[name].visible)
+  const childrenArray = React.Children.toArray(children)
+
+  useEffect(() => {
+    initializeInstance(name, defaultVisible)
+  }, [])
+
+  const saveVisible = (index: SidebarSide, value: boolean) => {
+    setVisible(name, index, value)
+  }
+
+  const saveSizes = (sizes: number[]) => {
+    setSizes(name, sizes)
+  }
+
+  const onChangeHandler = () => {
+    if (windowResizeOnChange) {
+      globalThis.dispatchEvent(new Event('resize'))
+    }
+  }
+
+  return (
+    <SidebarContext.Provider value={name}>
+      {sizes && visible && (
+        <Allotment onChange={onChangeHandler} onDragEnd={saveSizes} onVisibleChange={saveVisible} defaultSizes={sizes}>
+          <Allotment.Pane
+            snap
+            minSize={200}
+            maxSize={500}
+            preferredSize={300}
+            visible={visible[SidebarSide.LEFT]}
+            className="flex h-full flex-col"
+          >
+            {childrenArray[SidebarSide.LEFT]}
+          </Allotment.Pane>
+          <Allotment.Pane className="flex h-full flex-col">{childrenArray[SidebarSide.MIDDLE]}</Allotment.Pane>
+          {childrenArray[SidebarSide.RIGHT] && (
+            <Allotment.Pane
+              snap
+              minSize={200}
+              maxSize={500}
+              preferredSize={300}
+              visible={visible[SidebarSide.RIGHT]}
+              className="flex h-full flex-col"
+            >
+              {childrenArray[SidebarSide.RIGHT]}
+            </Allotment.Pane>
+          )}
+        </Allotment>
+      )}
+    </SidebarContext.Provider>
+  )
+}

--- a/src/main/react/app/components/sidebars-layout/sidebar-layout.tsx
+++ b/src/main/react/app/components/sidebars-layout/sidebar-layout.tsx
@@ -18,8 +18,8 @@ export default function SidebarLayout({
   windowResizeOnChange,
 }: Readonly<SidebarLayoutProperties>) {
   const { initializeInstance, setSizes, setVisible } = useSidebarStore()
-  const sizes = useSidebarStore((state) => state.instances[name]?.sizes) || []
-  const visible = useSidebarStore((state) => state.instances[name].visible)
+  const sizes = useSidebarStore((state) => state.instances[name]?.sizes ?? [])
+  const visible = useSidebarStore((state) => state.instances[name]?.visible ?? false)
   const childrenArray = React.Children.toArray(children)
 
   useEffect(() => {

--- a/src/main/react/app/components/sidebars-layout/sidebar-layout.tsx
+++ b/src/main/react/app/components/sidebars-layout/sidebar-layout.tsx
@@ -18,8 +18,8 @@ export default function SidebarLayout({
   windowResizeOnChange,
 }: Readonly<SidebarLayoutProperties>) {
   const { initializeInstance, setSizes, setVisible } = useSidebarStore()
-  const sizes = useSidebarStore((state) => state.instances[name]?.sizes ?? [])
-  const visible = useSidebarStore((state) => state.instances[name]?.visible ?? false)
+  const sizes = useSidebarStore((state) => state.instances[name]?.sizes) || []
+  const visible = useSidebarStore((state) => state.instances[name].visible)
   const childrenArray = React.Children.toArray(children)
 
   useEffect(() => {

--- a/src/main/react/app/routes/builder/builder-structure.tsx
+++ b/src/main/react/app/routes/builder/builder-structure.tsx
@@ -1,43 +1,31 @@
-import SidebarIcon from '/icons/solar/Sidebar Minimalistic.svg?react'
 import MagnifierIcon from '/icons/solar/Magnifier.svg?react'
 
-export default function BuilderStructure({ onClose }: Readonly<{ onClose: () => void }>) {
+export default function BuilderStructure() {
   return (
-    <div>
-      <div>
-        <div className="flex h-12 items-center gap-1 px-4">
-          <SidebarIcon
-            onClick={onClose}
-            className="rotate-180 fill-gray-950 hover:fill-[var(--color-brand)]"
-          ></SidebarIcon>
-          <div className="text-xl">Structure</div>
-        </div>
-        <div className="relative px-4">
-          <label htmlFor="search" className="absolute top-1/2 left-6 -translate-y-1/2">
-            <MagnifierIcon className="h-auto w-4 fill-gray-400" />
-          </label>
-          <input
-            id="search"
-            className="w-full rounded-full border border-gray-200 bg-gray-50 py-1 pr-4 pl-7"
-            type="search"
-            placeholder="Search"
-          />
-        </div>
+    <>
+      <div className="relative px-4">
+        <label htmlFor="search" className="absolute top-1/2 left-6 -translate-y-1/2">
+          <MagnifierIcon className="h-auto w-4 fill-gray-400" />
+        </label>
+        <input
+          id="search"
+          className="w-full rounded-full border border-gray-200 bg-gray-50 py-1 pr-4 pl-7"
+          type="search"
+          placeholder="Search"
+        />
       </div>
-      <div>
-        <ul>
-          <li>file1</li>
-          <li>file2</li>
-          <li>file3</li>
-          <li>file4</li>
-          <li>file5</li>
-          <li>file6</li>
-          <li>file7</li>
-          <li>file8</li>
-          <li>file9</li>
-          <li>file10</li>
-        </ul>
-      </div>
-    </div>
+      <ul>
+        <li>file1</li>
+        <li>file2</li>
+        <li>file3</li>
+        <li>file4</li>
+        <li>file5</li>
+        <li>file6</li>
+        <li>file7</li>
+        <li>file8</li>
+        <li>file9</li>
+        <li>file10</li>
+      </ul>
+    </>
   )
 }

--- a/src/main/react/app/routes/builder/builder.tsx
+++ b/src/main/react/app/routes/builder/builder.tsx
@@ -30,12 +30,12 @@ export default function Builder() {
   const nodeId = useNodeContextStore((state) => state.nodeId)
 
   return (
-    <SidebarLayout name="studio">
-      <div>
+    <SidebarLayout name="studio" windowResizeOnChange={true}>
+      <>
         <SidebarHeader side={SidebarSide.LEFT} title="Structure" />
         <BuilderStructure />
-      </div>
-      <div>
+      </>
+      <>
         <div className="flex">
           <SidebarContentClose side={SidebarSide.LEFT} />
           <div className="grow overflow-x-auto">
@@ -47,11 +47,11 @@ export default function Builder() {
           Path: {Object.entries(tabs).find(([key]) => key === selectedTab)?.[1]?.value}
         </div>
         <Flow showNodeContextMenu={setShowNodeContext} />
-      </div>
-      <div>
+      </>
+      <>
         <SidebarHeader side={SidebarSide.RIGHT} title={showNodeContext ? 'Edit node' : 'Palette'} />
         {showNodeContext ? <NodeContext nodeId={nodeId} setShowNodeContext={setShowNodeContext} /> : <BuilderContext />}
-      </div>
+      </>
     </SidebarLayout>
   )
 }

--- a/src/main/react/app/routes/builder/builder.tsx
+++ b/src/main/react/app/routes/builder/builder.tsx
@@ -1,13 +1,15 @@
-import { useEffect, useMemo, useState } from 'react'
-import { Allotment } from 'allotment'
+import { useState } from 'react'
 import Tabs, { type TabsList } from '~/components/tabs/tabs'
 import BuilderStructure from '~/routes/builder/builder-structure'
-import SidebarIcon from '/icons/solar/Sidebar Minimalistic.svg?react'
 import BuilderContext from '~/routes/builder/context/builder-context'
 import Flow from '~/routes/builder/canvas/flow'
 import FolderIcon from '/icons/solar/Folder.svg?react'
 import NodeContext from '~/routes/builder/context/node-context'
 import useNodeContextStore from '~/stores/node-context-store'
+import SidebarContentClose from '~/components/sidebars-layout/sidebar-content-close'
+import SidebarHeader from '~/components/sidebars-layout/sidebar-header'
+import { SidebarSide } from '~/components/sidebars-layout/sidebar-layout-store'
+import SidebarLayout from '~/components/sidebars-layout/sidebar-layout'
 
 const tabs = {
   tab1: { value: 'tab1', icon: FolderIcon },
@@ -22,127 +24,34 @@ const tabs = {
   tab10: { value: 'tab10' },
 } as TabsList
 
-enum SidebarIndex {
-  LEFT = 0,
-  RIGHT = 2,
-}
-
-const onChangeHandler = () => {
-  globalThis.dispatchEvent(new Event('resize'))
-}
-
 export default function Builder() {
   const [selectedTab, setSelectedTab] = useState<string | undefined>()
-
-  const [visible, setVisible] = useState([true, true, true])
   const [showNodeContext, setShowNodeContext] = useState(false)
-  const [hasReadFromLocalStorage, setHasReadFromLocalStorage] = useState(false)
-  const [sizes, setSizes] = useState<number[]>([])
-
-  const saveSizes = useMemo(
-    () => (sizes: number[]) => localStorage.setItem('builderSidebarSizes', JSON.stringify(sizes)),
-    [],
-  )
-
-  const saveVisible = useMemo(
-    () => (visible: boolean[]) => localStorage.setItem('builderSidebarVisible', JSON.stringify(visible)),
-    [],
-  )
-
-  useEffect(() => {
-    const savedSized = localStorage.getItem('builderSidebarSizes')
-    const savedVisible = localStorage.getItem('builderSidebarVisible')
-    if (savedSized) {
-      setSizes(JSON.parse(savedSized))
-    }
-    if (savedVisible) {
-      setVisible(JSON.parse(savedVisible))
-    }
-    setHasReadFromLocalStorage(true)
-  }, [])
-
-  const onVisibleChangeHandler = (index: SidebarIndex, value: boolean) => {
-    visible[index] = value
-    setVisible([...visible])
-    saveVisible(visible)
-  }
-
-  const toggleLeftVisible = () => {
-    toggleIndexVisible(SidebarIndex.LEFT)
-  }
-
-  const toggleRightVisible = () => {
-    toggleIndexVisible(SidebarIndex.RIGHT)
-  }
-
-  const toggleIndexVisible = (index: SidebarIndex) => {
-    onVisibleChangeHandler(index, !visible[index])
-  }
-
   const nodeId = useNodeContextStore((state) => state.nodeId)
 
   return (
-    <>
-      {hasReadFromLocalStorage && (
-        <Allotment
-          onChange={() => onChangeHandler()}
-          onDragEnd={saveSizes}
-          defaultSizes={sizes}
-          onVisibleChange={(index, value) => onVisibleChangeHandler(index, value)}
-        >
-          <Allotment.Pane
-            key="left"
-            snap
-            minSize={200}
-            maxSize={500}
-            preferredSize={300}
-            visible={visible[SidebarIndex.LEFT]}
-          >
-            <BuilderStructure onClose={toggleLeftVisible} />
-          </Allotment.Pane>
-          <Allotment.Pane key="content">
-            <div className="flex">
-              {!visible[SidebarIndex.LEFT] && (
-                <div className="flex aspect-square h-12 items-center justify-center border-r border-b border-gray-200">
-                  <SidebarIcon
-                    onClick={toggleLeftVisible}
-                    className="rotate-180 fill-gray-950 hover:fill-[var(--color-brand)]"
-                  ></SidebarIcon>
-                </div>
-              )}
-              <div className="grow overflow-x-auto">
-                <Tabs onSelectedTabChange={setSelectedTab} initialTabs={tabs} />
-              </div>
-              {!visible[SidebarIndex.RIGHT] && (
-                <div className="flex aspect-square h-12 items-center justify-center border-b border-l border-gray-200">
-                  <SidebarIcon
-                    onClick={toggleRightVisible}
-                    className="fill-gray-950 hover:fill-[var(--color-brand)]"
-                  ></SidebarIcon>
-                </div>
-              )}
-            </div>
-            <div className="h-12 border-b border-b-gray-200">
-              Path: {Object.entries(tabs).find(([key]) => key === selectedTab)?.[1]?.value}
-            </div>
-            <Flow showNodeContextMenu={setShowNodeContext} />
-          </Allotment.Pane>
-          <Allotment.Pane
-            key="right"
-            snap
-            minSize={200}
-            maxSize={2000}
-            preferredSize={300}
-            visible={visible[SidebarIndex.RIGHT]}
-          >
-            {showNodeContext ? (
-              <NodeContext nodeId={nodeId} setShowNodeContext={setShowNodeContext} />
-            ) : (
-              <BuilderContext onClose={toggleRightVisible} />
-            )}
-          </Allotment.Pane>
-        </Allotment>
-      )}
-    </>
+    <SidebarLayout name="studio">
+      <div>
+        <SidebarHeader side={SidebarSide.LEFT} title="Structure" />
+        <BuilderStructure />
+      </div>
+      <div>
+        <div className="flex">
+          <SidebarContentClose side={SidebarSide.LEFT} />
+          <div className="grow overflow-x-auto">
+            <Tabs onSelectedTabChange={setSelectedTab} initialTabs={tabs} />
+          </div>
+          <SidebarContentClose side={SidebarSide.RIGHT} />
+        </div>
+        <div className="h-12 border-b border-b-gray-200">
+          Path: {Object.entries(tabs).find(([key]) => key === selectedTab)?.[1]?.value}
+        </div>
+        <Flow showNodeContextMenu={setShowNodeContext} />
+      </div>
+      <div>
+        <SidebarHeader side={SidebarSide.RIGHT} title={showNodeContext ? 'Edit node' : 'Palette'} />
+        {showNodeContext ? <NodeContext nodeId={nodeId} setShowNodeContext={setShowNodeContext} /> : <BuilderContext />}
+      </div>
+    </SidebarLayout>
   )
 }

--- a/src/main/react/app/routes/builder/context/builder-context.tsx
+++ b/src/main/react/app/routes/builder/context/builder-context.tsx
@@ -2,9 +2,9 @@ import MagnifierIcon from '/icons/solar/Magnifier.svg?react'
 import useFrankDocStore from '~/stores/frank-doc-store'
 import useNodeContextStore from '~/stores/node-context-store'
 import useFlowStore from '~/stores/flow-store'
-import {getElementTypeFromName} from '~/routes/builder/node-translator-module'
+import { getElementTypeFromName } from '~/routes/builder/node-translator-module'
 
-import {useEffect, useState} from 'react'
+import { useEffect, useState } from 'react'
 import SortedElements from '~/routes/builder/context/sorted-elements'
 
 export default function BuilderContext() {
@@ -67,43 +67,33 @@ export default function BuilderContext() {
   const elementsToRender = searchTerm ? filteredGroupedElements : groupedElements
 
   return (
-    <div className="h-full">
-      <div>
-        <div className="relative px-4">
-          <label htmlFor="search" className="absolute top-1/2 left-6 -translate-y-1/2">
-            <MagnifierIcon className="h-auto w-4 fill-gray-400" />
-          </label>
-          <input
-            id="search"
-            className="w-full rounded-full border border-gray-200 bg-gray-50 py-1 pr-4 pl-7"
-            type="search"
-            placeholder="Search"
-            value={searchTerm}
-            onChange={(event) => setSearchTerm(event.target.value)}
-          />
-        </div>
+    <div className="flex h-full flex-col overflow-hidden">
+      <div className="relative px-4 py-2">
+        <label htmlFor="search" className="absolute top-1/2 left-6 -translate-y-1/2">
+          <MagnifierIcon className="h-auto w-4 fill-gray-400" />
+        </label>
+        <input
+          id="search"
+          className="w-full rounded-full border border-gray-200 bg-gray-50 py-1 pr-4 pl-7"
+          type="search"
+          placeholder="Search"
+          value={searchTerm}
+          onChange={(event) => setSearchTerm(event.target.value)}
+        />
       </div>
-      <div className="h-full">
-        <ul className="h-[calc(100vh-100px)] overflow-y-auto p-4">
-          {isLoading && <li>Loading...</li>}
-          {error && <li>Error: {error}</li>}
-          {!isLoading && Object.keys(elementsToRender).length === 0 && (
-            <li className="text-gray-500 italic">No results found.</li>
-          )}
-          {!isLoading &&
-            Object.entries(elementsToRender)
-              .sort(([typeA], [typeB]) => typeA.localeCompare(typeB))
-              .map(([type, items]) => (
-                <SortedElements
-                  key={type}
-                  type={type}
-                  items={items}
-                  onDragStart={onDragStart}
-                  searchTerm={searchTerm}
-                />
-              ))}
-        </ul>
-      </div>
+      <ul className="flex-1 overflow-y-auto p-4">
+        {isLoading && <li>Loading...</li>}
+        {error && <li>Error: {error}</li>}
+        {!isLoading && Object.keys(elementsToRender).length === 0 && (
+          <li className="text-gray-500 italic">No results found.</li>
+        )}
+        {!isLoading &&
+          Object.entries(elementsToRender)
+            .sort(([typeA], [typeB]) => typeA.localeCompare(typeB))
+            .map(([type, items]) => (
+              <SortedElements key={type} type={type} items={items} onDragStart={onDragStart} searchTerm={searchTerm} />
+            ))}
+      </ul>
     </div>
   )
 }

--- a/src/main/react/app/routes/builder/context/builder-context.tsx
+++ b/src/main/react/app/routes/builder/context/builder-context.tsx
@@ -1,14 +1,13 @@
-import SidebarIcon from '/icons/solar/Sidebar Minimalistic.svg?react'
 import MagnifierIcon from '/icons/solar/Magnifier.svg?react'
 import useFrankDocStore from '~/stores/frank-doc-store'
 import useNodeContextStore from '~/stores/node-context-store'
 import useFlowStore from '~/stores/flow-store'
-import { getElementTypeFromName } from '~/routes/builder/node-translator-module'
+import {getElementTypeFromName} from '~/routes/builder/node-translator-module'
 
-import { useEffect, useState } from 'react'
+import {useEffect, useState} from 'react'
 import SortedElements from '~/routes/builder/context/sorted-elements'
 
-export default function BuilderContext({ onClose }: Readonly<{ onClose: () => void }>) {
+export default function BuilderContext() {
   const { frankDocRaw, isLoading, error } = useFrankDocStore()
   const { setAttributes, setNodeId } = useNodeContextStore((state) => state)
   const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({})
@@ -70,11 +69,6 @@ export default function BuilderContext({ onClose }: Readonly<{ onClose: () => vo
   return (
     <div className="h-full">
       <div>
-        <div className="flex h-12 items-center gap-1 px-4">
-          <div className="text-xl">Palette</div>
-          <div className="grow"></div>
-          <SidebarIcon onClick={onClose} className="fill-gray-950 hover:fill-[var(--color-brand)]" />
-        </div>
         <div className="relative px-4">
           <label htmlFor="search" className="absolute top-1/2 left-6 -translate-y-1/2">
             <MagnifierIcon className="h-auto w-4 fill-gray-400" />

--- a/src/main/react/app/routes/builder/context/node-context.tsx
+++ b/src/main/react/app/routes/builder/context/node-context.tsx
@@ -87,11 +87,7 @@ export default function NodeContext({
   }
 
   return (
-    <div className="flex h-full flex-col">
-      <div className="flex h-12 items-center gap-1 px-4">
-        <div className="text-xl">Attributes</div>
-        <div className="grow" />
-      </div>
+    <>
       <div className="flex-1 overflow-y-auto px-4">
         <div className="w-full max-w-sm space-y-4 rounded-lg bg-white p-6 shadow-md">
           <h1>For node with id: {nodeId}</h1>
@@ -139,6 +135,6 @@ export default function NodeContext({
           </button>
         </div>
       </div>
-    </div>
+    </>
   )
 }

--- a/src/main/react/app/routes/editor/editor-files.tsx
+++ b/src/main/react/app/routes/editor/editor-files.tsx
@@ -1,4 +1,10 @@
-import { Tree, type TreeRef, UncontrolledTreeEnvironment } from 'react-complex-tree'
+import {
+  Tree,
+  type TreeItem,
+  type TreeItemRenderContext,
+  type TreeRef,
+  UncontrolledTreeEnvironment,
+} from 'react-complex-tree'
 import '/styles/editor-files.css'
 import FolderIcon from '/icons/solar/Folder.svg?react'
 import FolderOpenIcon from '/icons/solar/Folder Open.svg?react'
@@ -6,7 +12,6 @@ import CodeIcon from '/icons/solar/Code.svg?react'
 import AltArrowRightIcon from '/icons/solar/Alt Arrow Right.svg?react'
 import AltArrowDownIcon from '/icons/solar/Alt Arrow Down.svg?react'
 import React, { type RefObject, useRef } from 'react'
-import SidebarIcon from '/icons/solar/Sidebar Minimalistic.svg?react'
 import MagnifierIcon from '/icons/solar/Magnifier.svg?react'
 import EditorFilesDataProvider from '~/routes/editor/editor-files-data-provider'
 
@@ -15,10 +20,9 @@ const TREE_ID = 'editor-files-tree'
 interface EditorFilesTreeProperties {
   search?: string
   ref?: RefObject<unknown>
-  onClose: () => void
 }
 
-export default function EditorFiles({ onClose }: Readonly<EditorFilesTreeProperties>) {
+export default function EditorFiles({}: Readonly<EditorFilesTreeProperties>) {
   const tree = useRef<TreeRef>(null)
   const [autoFocus, setAutoFocus] = React.useState(false)
 
@@ -32,15 +36,39 @@ export default function EditorFiles({ onClose }: Readonly<EditorFilesTreePropert
     tree.current?.focusTree(focus)
   }
 
+  const renderItemArrow = ({ item, context }: { item: TreeItem<unknown>; context: TreeItemRenderContext }) => {
+    if (!item.isFolder) {
+      return null
+    }
+    const Icon = context.isExpanded ? AltArrowDownIcon : AltArrowRightIcon
+    return (
+      <Icon
+        onClick={context.toggleExpandedState}
+        className="rct-tree-item-arrow-isFolder rct-tree-item-arrow fill-gray-950"
+      />
+    )
+  }
+
+  const renderItemTitle = ({
+    title,
+    item,
+    context,
+  }: {
+    title: string
+    item: TreeItem<unknown>
+    context: TreeItemRenderContext
+  }) => {
+    const Icon = (item.isFolder && (context.isExpanded ? FolderOpenIcon : FolderIcon)) || CodeIcon
+    return (
+      <>
+        <Icon className="w-4 flex-shrink-0 fill-gray-950" />
+        <span className="font-inter ml-1 overflow-hidden text-nowrap text-ellipsis">{title}</span>
+      </>
+    )
+  }
+
   return (
-    <div className="flex h-full flex-col">
-      <div className="flex h-12 items-center gap-1 px-4">
-        <SidebarIcon
-          onClick={onClose}
-          className="rotate-180 fill-gray-950 hover:fill-[var(--color-brand)]"
-        ></SidebarIcon>
-        <div className="text-xl">Files</div>
-      </div>
+    <>
       <div className="relative px-4">
         <label htmlFor="search" className="absolute top-1/2 left-6 -translate-y-1/2">
           <MagnifierIcon className="h-auto w-4 fill-gray-400" />
@@ -64,31 +92,12 @@ export default function EditorFiles({ onClose }: Readonly<EditorFilesTreePropert
           canDropOnFolder={true}
           canSearch={false}
           autoFocus={autoFocus}
-          renderItemArrow={({ item, context }) => {
-            if (!item.isFolder) {
-              return null
-            }
-            const Icon = context.isExpanded ? AltArrowDownIcon : AltArrowRightIcon
-            return (
-              <Icon
-                onClick={context.toggleExpandedState}
-                className="rct-tree-item-arrow-isFolder rct-tree-item-arrow fill-gray-950"
-              />
-            )
-          }}
-          renderItemTitle={({ title, item, context }) => {
-            const Icon = item.isFolder ? (context.isExpanded ? FolderOpenIcon : FolderIcon) : CodeIcon
-            return (
-              <>
-                <Icon className="w-4 flex-shrink-0 fill-gray-950" />
-                <span className="font-inter ml-1 overflow-hidden text-nowrap text-ellipsis">{title}</span>
-              </>
-            )
-          }}
+          renderItemArrow={renderItemArrow}
+          renderItemTitle={renderItemTitle}
         >
           <Tree treeId={TREE_ID} rootItem="root" ref={tree} treeLabel="Tree Example" />
         </UncontrolledTreeEnvironment>
       </div>
-    </div>
+    </>
   )
 }

--- a/src/main/react/app/routes/editor/editor.tsx
+++ b/src/main/react/app/routes/editor/editor.tsx
@@ -25,12 +25,12 @@ export default function CodeEditor() {
   const [selectedTab, setSelectedTab] = useState<string | undefined>()
 
   return (
-    <SidebarLayout name="editor">
-      <div>
+    <SidebarLayout name="editor" windowResizeOnChange={true}>
+      <>
         <SidebarHeader side={SidebarSide.LEFT} title="Files" />
         <EditorFiles></EditorFiles>
-      </div>
-      <div>
+      </>
+      <>
         <div className="flex">
           <SidebarContentClose side={SidebarSide.LEFT} />
           <div className="grow overflow-x-auto">
@@ -43,11 +43,11 @@ export default function CodeEditor() {
         <div className="h-full">
           <Editor></Editor>
         </div>
-      </div>
-      <div>
+      </>
+      <>
         <SidebarHeader side={SidebarSide.RIGHT} title="Preview" />
         <div className="h-full">Preview</div>
-      </div>
+      </>
     </SidebarLayout>
   )
 }

--- a/src/main/react/app/routes/editor/editor.tsx
+++ b/src/main/react/app/routes/editor/editor.tsx
@@ -1,10 +1,12 @@
-import { useEffect, useMemo, useState } from 'react'
-import { Allotment } from 'allotment'
+import { useState } from 'react'
 import Tabs, { type TabsList } from '~/components/tabs/tabs'
-import SidebarIcon from '/icons/solar/Sidebar Minimalistic.svg?react'
 import { Editor } from '@monaco-editor/react'
 import EditorFiles from '~/routes/editor/editor-files'
 import FolderIcon from '/icons/solar/Folder.svg?react'
+import SidebarHeader from '~/components/sidebars-layout/sidebar-header'
+import SidebarLayout from '~/components/sidebars-layout/sidebar-layout'
+import { SidebarSide } from '~/components/sidebars-layout/sidebar-layout-store'
+import SidebarContentClose from '~/components/sidebars-layout/sidebar-content-close'
 
 const tabs = {
   tab1: { value: 'tab1', icon: FolderIcon },
@@ -19,104 +21,33 @@ const tabs = {
   tab10: { value: 'tab10' },
 } as TabsList
 
-enum SidebarIndex {
-  LEFT = 0,
-  RIGHT = 2,
-}
-
-const onChangeHandler = () => {
-  globalThis.dispatchEvent(new Event('resize'))
-}
-
 export default function CodeEditor() {
   const [selectedTab, setSelectedTab] = useState<string | undefined>()
 
-  const [visible, setVisible] = useState([true, true, true])
-  const [hasReadFromLocalStorage, setHasReadFromLocalStorage] = useState(false)
-  const [sizes, setSizes] = useState<number[]>([])
-
-  const saveSizes = useMemo(
-    () => (sizes: number[]) => localStorage.setItem('editorSidebarSizes', JSON.stringify(sizes)),
-    [],
-  )
-
-  const saveVisible = useMemo(
-    () => (visible: boolean[]) => localStorage.setItem('editorSidebarVisible', JSON.stringify(visible)),
-    [],
-  )
-
-  useEffect(() => {
-    const savedSizes = localStorage.getItem('editorSidebarSizes')
-    const savedVisible = localStorage.getItem('editorSidebarVisible')
-    if (savedSizes) {
-      setSizes(JSON.parse(savedSizes))
-    }
-    if (savedVisible) {
-      setVisible(JSON.parse(savedVisible))
-    }
-    setHasReadFromLocalStorage(true)
-  }, [])
-
-  const onVisibleChangeHandler = (index: SidebarIndex, value: boolean) => {
-    visible[index] = value
-    setVisible([...visible])
-    saveVisible(visible)
-  }
-
-  const toggleLeftVisible = () => {
-    toggleIndexVisible(SidebarIndex.LEFT)
-  }
-
-  const toggleRightVisible = () => {
-    toggleIndexVisible(SidebarIndex.RIGHT)
-  }
-
-  const toggleIndexVisible = (index: SidebarIndex) => {
-    onVisibleChangeHandler(index, !visible[index])
-  }
-
   return (
-    <>
-      {hasReadFromLocalStorage && (
-        <Allotment
-          onChange={() => onChangeHandler()}
-          onDragEnd={saveSizes}
-          defaultSizes={sizes}
-          onVisibleChange={(index, value) => onVisibleChangeHandler(index, value)}
-        >
-          <Allotment.Pane
-            key="left"
-            snap
-            minSize={200}
-            maxSize={500}
-            preferredSize={300}
-            visible={visible[SidebarIndex.LEFT]}
-          >
-            <EditorFiles onClose={toggleLeftVisible}></EditorFiles>
-          </Allotment.Pane>
-          <Allotment.Pane key="content">
-            <div className="flex">
-              {!visible[SidebarIndex.LEFT] && (
-                <div className="flex aspect-square h-12 items-center justify-center border-r border-b border-gray-200">
-                  <SidebarIcon
-                    onClick={toggleLeftVisible}
-                    className="rotate-180 fill-gray-950 hover:fill-[var(--color-brand)]"
-                  ></SidebarIcon>
-                </div>
-              )}
-              <div className="grow overflow-x-auto">
-                <Tabs onSelectedTabChange={setSelectedTab} initialTabs={tabs} />
-              </div>
-            </div>
-            <div className="h-12 border-b border-b-gray-200">
-              Path: {Object.entries(tabs).find(([key]) => key === selectedTab)?.[1]?.value}
-            </div>
-            <div className="h-full">
-              <Editor></Editor>
-            </div>
-          </Allotment.Pane>
-        </Allotment>
-      )}
-    </>
+    <SidebarLayout name="editor">
+      <div>
+        <SidebarHeader side={SidebarSide.LEFT} title="Files" />
+        <EditorFiles></EditorFiles>
+      </div>
+      <div>
+        <div className="flex">
+          <SidebarContentClose side={SidebarSide.LEFT} />
+          <div className="grow overflow-x-auto">
+            <Tabs onSelectedTabChange={setSelectedTab} initialTabs={tabs} />
+          </div>
+        </div>
+        <div className="h-12 border-b border-b-gray-200">
+          Path: {Object.entries(tabs).find(([key]) => key === selectedTab)?.[1]?.value}
+        </div>
+        <div className="h-full">
+          <Editor></Editor>
+        </div>
+      </div>
+      <div>
+        <SidebarHeader side={SidebarSide.RIGHT} title="Preview" />
+        <div className="h-full">Preview</div>
+      </div>
+    </SidebarLayout>
   )
 }

--- a/src/main/react/app/routes/help/help-topic-tree-items.ts
+++ b/src/main/react/app/routes/help/help-topic-tree-items.ts
@@ -6,7 +6,7 @@ import React from 'react'
 
 export type HelpTopicTreeItem = TreeItem<HelpTopicTreeItemData>
 
-interface HelpTopicTreeItemData {
+export interface HelpTopicTreeItemData {
   title: string
   description: string
   content?: React.FC

--- a/src/main/react/app/routes/help/help-topics.tsx
+++ b/src/main/react/app/routes/help/help-topics.tsx
@@ -1,60 +1,62 @@
-import SidebarIcon from '/icons/solar/Sidebar Minimalistic.svg?react'
-import { StaticTreeDataProvider, Tree, type TreeRef, UncontrolledTreeEnvironment } from 'react-complex-tree'
+import {
+  StaticTreeDataProvider,
+  Tree,
+  type TreeItemIndex,
+  type TreeItemRenderContext,
+  type TreeRef,
+  UncontrolledTreeEnvironment,
+} from 'react-complex-tree'
 import AltArrowRightIcon from '/icons/solar/Alt Arrow Right.svg?react'
 import AltArrowDownIcon from '/icons/solar/Alt Arrow Down.svg?react'
 import { useRef } from 'react'
 import helpTopics, { type HelpTopicTreeItem } from './help-topic-tree-items'
 import '/styles/editor-files.css'
-import { redirect, useNavigate } from 'react-router'
+import { useNavigate } from 'react-router'
 
 interface HelpCategoriesProperties {
   selectedTopic: keyof typeof helpTopics
-  onClose: () => void
 }
 
 const TREE_ID = 'help-topics-tree'
 
-export default function HelpTopics({ selectedTopic, onClose }: Readonly<HelpCategoriesProperties>) {
+export default function HelpTopics({ selectedTopic }: Readonly<HelpCategoriesProperties>) {
   const navigate = useNavigate()
   const tree = useRef<TreeRef>(null)
 
-  return (
-    <div className="flex h-full flex-col">
-      <div className="flex h-12 items-center gap-1 px-4">
-        <SidebarIcon
-          onClick={onClose}
-          className="rotate-180 fill-gray-950 hover:fill-[var(--color-brand)]"
-        ></SidebarIcon>
-        <div className="text-xl">Topics</div>
-      </div>
+  const navigateToTopic = (items: TreeItemIndex[]) => navigate(`/help/${items[0]}`)
 
-      <div className="overflow-auto pr-2">
+  const renderItemArrow = ({ item, context }: { item: HelpTopicTreeItem; context: TreeItemRenderContext }) => {
+    if (!item.isFolder) return null
+
+    const Icon = context.isExpanded ? AltArrowDownIcon : AltArrowRightIcon
+    return (
+      <Icon
+        onClick={context.toggleExpandedState}
+        className="rct-tree-item-arrow-isFolder rct-tree-item-arrow fill-gray-950"
+      />
+    )
+  }
+
+  const renderItemTitle = ({ title }: { title: string }) => (
+    <span className="font-inter ml-1 overflow-hidden text-nowrap text-ellipsis">{title}</span>
+  )
+
+  return (
+    <>
+      <div className="overflow-auto px-2">
         <UncontrolledTreeEnvironment
           dataProvider={new StaticTreeDataProvider(helpTopics)}
-          getItemTitle={(item: HelpTopicTreeItem): string => item.data.title}
+          getItemTitle={({ data }) => data.title}
           viewState={{ [TREE_ID]: { selectedItems: [selectedTopic] } }}
           disableMultiselect={true}
-          onSelectItems={(items) => navigate(`/help/${items[0]}`)}
+          onSelectItems={navigateToTopic}
           canSearch={false}
-          renderItemArrow={({ item, context }) => {
-            if (!item.isFolder) {
-              return null
-            }
-            const Icon = context.isExpanded ? AltArrowDownIcon : AltArrowRightIcon
-            return (
-              <Icon
-                onClick={context.toggleExpandedState}
-                className="rct-tree-item-arrow-isFolder rct-tree-item-arrow fill-gray-950"
-              />
-            )
-          }}
-          renderItemTitle={({ title }) => {
-            return <span className="font-inter ml-1 overflow-hidden text-nowrap text-ellipsis">{title}</span>
-          }}
+          renderItemArrow={renderItemArrow}
+          renderItemTitle={renderItemTitle}
         >
           <Tree treeId={TREE_ID} rootItem="root" ref={tree} treeLabel="Tree Example" />
         </UncontrolledTreeEnvironment>
       </div>
-    </div>
+    </>
   )
 }

--- a/src/main/react/app/routes/help/help.tsx
+++ b/src/main/react/app/routes/help/help.tsx
@@ -18,11 +18,11 @@ export default function Help() {
 
   return (
     <SidebarLayout name="help">
-      <div>
+      <>
         <SidebarHeader side={SidebarSide.LEFT} title="Topics" />
         <HelpTopics selectedTopic={helpTopicKey} />
-      </div>
-      <div>
+      </>
+      <>
         <div className="flex">
           <SidebarContentClose side={SidebarSide.LEFT} />
           <div className="flex h-12 grow items-center border-b border-b-gray-200 px-4">
@@ -40,7 +40,7 @@ export default function Help() {
             </div>
           )}
         </div>
-      </div>
+      </>
     </SidebarLayout>
   )
 }

--- a/src/main/react/app/routes/help/help.tsx
+++ b/src/main/react/app/routes/help/help.tsx
@@ -1,18 +1,11 @@
-import React, { useEffect, useMemo, useState } from 'react'
-import { Allotment } from 'allotment'
-import SidebarIcon from '/icons/solar/Sidebar Minimalistic.svg?react'
 import '/styles/markdown.css'
 import helpTopicTreeItems, { type HelpTopicTreeItem } from './help-topic-tree-items'
 import { useParams } from 'react-router'
+import SidebarContentClose from '~/components/sidebars-layout/sidebar-content-close'
+import { SidebarSide } from '~/components/sidebars-layout/sidebar-layout-store'
+import SidebarLayout from '~/components/sidebars-layout/sidebar-layout'
+import SidebarHeader from '~/components/sidebars-layout/sidebar-header'
 import HelpTopics from '~/routes/help/help-topics'
-
-enum SidebarIndex {
-  LEFT = 0,
-  RIGHT = 2,
-}
-
-const LOCAL_STORAGE_SIZES_KEY = 'helpSidebarSizes'
-const LOCAL_STORAGE_VISIBLE_KEY = 'helpSidebarVisible'
 
 const firstTopic = Object.keys(helpTopicTreeItems)[1]
 
@@ -21,107 +14,33 @@ export default function Help() {
   const helpTopicKey = topic ?? firstTopic
   const helpTopic: HelpTopicTreeItem | undefined = helpTopicTreeItems[helpTopicKey]
 
-  const [visible, setVisible] = useState([true, true, true])
-  const [hasReadFromLocalStorage, setHasReadFromLocalStorage] = useState(false)
-  const [sizes, setSizes] = useState<number[]>([])
-
-  const saveSizes = useMemo(
-    () => (sizes: number[]) => localStorage.setItem(LOCAL_STORAGE_SIZES_KEY, JSON.stringify(sizes)),
-    [],
-  )
-
-  const saveVisible = useMemo(
-    () => (visible: boolean[]) => localStorage.setItem(LOCAL_STORAGE_VISIBLE_KEY, JSON.stringify(visible)),
-    [],
-  )
-
-  useEffect(() => {
-    const savedSized = localStorage.getItem(LOCAL_STORAGE_SIZES_KEY)
-    const savedVisible = localStorage.getItem(LOCAL_STORAGE_VISIBLE_KEY)
-    if (savedSized) {
-      setSizes(JSON.parse(savedSized))
-    }
-    if (savedVisible) {
-      setVisible(JSON.parse(savedVisible))
-    }
-    setHasReadFromLocalStorage(true)
-  }, [])
-
-  const onVisibleChangeHandler = (index: SidebarIndex, value: boolean) => {
-    visible[index] = value
-    setVisible([...visible])
-    saveVisible(visible)
-  }
-
-  const toggleLeftVisible = () => {
-    toggleIndexVisible(SidebarIndex.LEFT)
-  }
-
-  const toggleRightVisible = () => {
-    toggleIndexVisible(SidebarIndex.RIGHT)
-  }
-
-  const toggleIndexVisible = (index: SidebarIndex) => {
-    onVisibleChangeHandler(index, !visible[index])
-  }
+  const MarkdownContent = helpTopic?.data.content
 
   return (
-    <>
-      {hasReadFromLocalStorage && (
-        <Allotment
-          onDragEnd={saveSizes}
-          defaultSizes={sizes}
-          onVisibleChange={(index, value) => onVisibleChangeHandler(index, value)}
-        >
-          <Allotment.Pane
-            key="left"
-            snap
-            minSize={200}
-            maxSize={500}
-            preferredSize={300}
-            visible={visible[SidebarIndex.LEFT]}
-          >
-            <HelpTopics selectedTopic={helpTopicKey} onClose={toggleLeftVisible} />
-          </Allotment.Pane>
-          <Allotment.Pane key="content" className="flex flex-col">
-            <div className="flex h-12">
-              {!visible[SidebarIndex.LEFT] && (
-                <div className="flex aspect-square items-center justify-center border-r border-b border-gray-200">
-                  <SidebarIcon
-                    onClick={toggleLeftVisible}
-                    className="rotate-180 fill-gray-950 hover:fill-[var(--color-brand)]"
-                  ></SidebarIcon>
-                </div>
-              )}
-              <div className="flex grow items-center border-b border-b-gray-200 px-4">
-                <div className="flex h-max items-end gap-4">
-                  <h1 className="text-xl font-medium">{helpTopic?.data.title ?? 'Oops'}</h1>
-                  <p>{helpTopic?.data.description ?? "Topic can't be retrieved"}</p>
-                </div>
-              </div>
-              {!visible[SidebarIndex.RIGHT] && (
-                <div className="flex aspect-square items-center justify-center border-b border-l border-gray-200">
-                  <SidebarIcon
-                    onClick={toggleRightVisible}
-                    className="fill-gray-950 hover:fill-[var(--color-brand)]"
-                  ></SidebarIcon>
-                </div>
-              )}
+    <SidebarLayout name="help">
+      <div>
+        <SidebarHeader side={SidebarSide.LEFT} title="Topics" />
+        <HelpTopics selectedTopic={helpTopicKey} />
+      </div>
+      <div>
+        <div className="flex">
+          <SidebarContentClose side={SidebarSide.LEFT} />
+          <div className="flex h-12 grow items-center border-b border-b-gray-200 px-4">
+            <div className="flex h-max items-end gap-4">
+              <h1 className="text-xl font-medium">{helpTopic?.data.title ?? 'Oops'}</h1>
+              <p>{helpTopic?.data.description ?? "Topic can't be retrieved"}</p>
             </div>
-            <div className="markdown-body h-full overflow-auto p-4">
-              {React.createElement(
-                helpTopic?.data.content ??
-                  (() => (
-                    <div>
-                      The topic with id: <code>{topic}</code> does not seem to exist, it might have been moved or
-                      deleted. Please select a different topic from the left sidebar.
-                    </div>
-                  )),
-              )}
+          </div>
+        </div>
+        <div className="markdown-body h-full overflow-auto p-4">
+          {(MarkdownContent && <MarkdownContent />) || (
+            <div>
+              The topic with id: <code>{topic}</code> does not seem to exist, it might have been moved or deleted.
+              Please select a different topic from the left sidebar.
             </div>
-          </Allotment.Pane>
-        </Allotment>
-      )}
-    </>
+          )}
+        </div>
+      </div>
+    </SidebarLayout>
   )
 }


### PR DESCRIPTION
Replace custom sidebar state and Allotment layout with reusable SidebarLayout components for consistent sidebar behavior and styling. Remove localStorage persistence and manual visibility toggles in favor of SidebarLayout's built-in controls. Simplify Help component by delegating sidebar header, content, and close button to dedicated components. This improves maintainability and aligns with app-wide sidebar patterns.