### PR TITLE
Hotfix pages not loading when layout store has not been initialized

### DIFF
--- a/src/main/react/app/components/sidebars-layout/sidebar-content-close.tsx
+++ b/src/main/react/app/components/sidebars-layout/sidebar-content-close.tsx
@@ -6,7 +6,7 @@ import { SidebarContext } from '~/components/sidebars-layout/sidebar-layout'
 export default function SidebarContentClose(properties: Readonly<SidebarsCloseProperties>) {
   const layoutName = useContext(SidebarContext)
   if (!layoutName) throw new Error('SidebarsClose must be used within a SidebarLayout or be provided a layoutName prop')
-  const visible = useSidebarStore((sate) => sate.instances[layoutName]?.visible[properties.side]) ?? []
+  const visible = useSidebarStore((sate) => sate.instances[layoutName]?.visible[properties.side]) ?? null
 
   if (!visible) {
     return (

--- a/src/main/react/app/components/sidebars-layout/sidebar-content-close.tsx
+++ b/src/main/react/app/components/sidebars-layout/sidebar-content-close.tsx
@@ -6,7 +6,7 @@ import { SidebarContext } from '~/components/sidebars-layout/sidebar-layout'
 export default function SidebarContentClose(properties: Readonly<SidebarsCloseProperties>) {
   const layoutName = useContext(SidebarContext)
   if (!layoutName) throw new Error('SidebarsClose must be used within a SidebarLayout or be provided a layoutName prop')
-  const visible = useSidebarStore((sate) => sate.instances[layoutName].visible[properties.side])
+  const visible = useSidebarStore((sate) => sate.instances[layoutName]?.visible[properties.side]) ?? []
 
   if (!visible) {
     return (

--- a/src/main/react/app/components/sidebars-layout/sidebar-layout.tsx
+++ b/src/main/react/app/components/sidebars-layout/sidebar-layout.tsx
@@ -18,8 +18,8 @@ export default function SidebarLayout({
   windowResizeOnChange,
 }: Readonly<SidebarLayoutProperties>) {
   const { initializeInstance, setSizes, setVisible } = useSidebarStore()
-  const sizes = useSidebarStore((state) => state.instances[name]?.sizes) || []
-  const visible = useSidebarStore((state) => state.instances[name].visible)
+  const sizes = useSidebarStore((state) => state.instances[name]?.sizes) ?? []
+  const visible = useSidebarStore((state) => state.instances[name]?.visible) ?? []
   const childrenArray = React.Children.toArray(children)
 
   useEffect(() => {


### PR DESCRIPTION
### Description

- Fixed an issue where pages would not load if the layout store had not been initialized.