### PR TITLE
Nodes can now be grouped together

### DIFF
--- a/src/main/react/app/routes/builder/canvas/edges.ts
+++ b/src/main/react/app/routes/builder/canvas/edges.ts
@@ -3,41 +3,46 @@ export const initialEdges = [
     id: '0-1',
     source: '0',
     target: '1',
+    data: {
+      label: 'SUCCESS',
+    },
     type: 'frankEdge',
   },
   {
     id: '1-2',
     source: '1',
     target: '2',
-    sourceHandle: '1',
+    data: {
+      label: 'SUCCESS',
+    },
     type: 'frankEdge',
   },
   {
     id: '2-3',
     source: '2',
     target: '3',
-    sourceHandle: '1',
+    data: {
+      label: 'SUCCESS',
+    },
     type: 'frankEdge',
   },
   {
     id: '3-4',
     source: '3',
     target: '4',
-    sourceHandle: '1',
+    data: {
+      label: 'SUCCESS',
+    },
     type: 'frankEdge',
   },
   {
-    id: '4-5',
-    source: '4',
-    target: '5',
-    sourceHandle: '1',
-    type: 'frankEdge',
-  },
-  {
-    id: '3-6',
-    source: '3',
+    id: '2-5',
+    source: '2',
     sourceHandle: '2',
-    target: '6',
+    target: '5',
+    data: {
+      label: 'FAILURE',
+    },
     type: 'frankEdge',
   },
 ]

--- a/src/main/react/app/routes/builder/canvas/flow.tsx
+++ b/src/main/react/app/routes/builder/canvas/flow.tsx
@@ -167,7 +167,7 @@ function FlowCanvas({ showNodeContextMenu }: Readonly<{ showNodeContextMenu: (b:
 
   const degroupNodes = (selectedNodes: FlowNode[], parentId: string, allNodes: FlowNode[]): FlowNode[] => {
     const groupNode = allNodes.find((node) => node.id === parentId)
-    if (!groupNode) return nodes
+    if (!groupNode) return allNodes
 
     const groupX = groupNode.position.x
     const groupY = groupNode.position.y

--- a/src/main/react/app/routes/builder/canvas/nodes.ts
+++ b/src/main/react/app/routes/builder/canvas/nodes.ts
@@ -3,12 +3,6 @@ export const initialNodes: Node[] = [
   {
     id: '0',
     position: { x: 0, y: 0 },
-    data: {},
-    type: 'startNode',
-  },
-  {
-    id: '1',
-    position: { x: 0, y: 0 },
     data: {
       subtype: 'Receiver',
       type: 'Receiver',
@@ -25,8 +19,8 @@ export const initialNodes: Node[] = [
     type: 'frankNode',
   },
   {
-    id: '2',
-    position: { x: 0, y: 0 },
+    id: '1',
+    position: { x: 450, y: 0 },
     data: {
       subtype: 'Senderpipe',
       type: 'Pipe',
@@ -45,8 +39,8 @@ export const initialNodes: Node[] = [
     type: 'frankNode',
   },
   {
-    id: '3',
-    position: { x: 0, y: 0 },
+    id: '2',
+    position: { x: 900, y: 0 },
     data: {
       subtype: 'XsltPipe',
       type: 'Pipe',
@@ -63,8 +57,8 @@ export const initialNodes: Node[] = [
     type: 'frankNode',
   },
   {
-    id: '4',
-    position: { x: 0, y: 0 },
+    id: '3',
+    position: { x: 1350, y: -200 },
     data: {
       subtype: 'SenderPipe',
       type: 'Pipe',
@@ -85,8 +79,8 @@ export const initialNodes: Node[] = [
     type: 'frankNode',
   },
   {
-    id: '5',
-    position: { x: 0, y: 0 },
+    id: '4',
+    position: { x: 1800, y: 0 },
     data: {
       subtype: 'Exit',
       type: 'Exit',
@@ -95,8 +89,8 @@ export const initialNodes: Node[] = [
     type: 'exitNode',
   },
   {
-    id: '6',
-    position: { x: 0, y: 0 },
+    id: '5',
+    position: { x: 1800, y: 200 },
     data: {
       subtype: 'Exit',
       type: 'Exit',

--- a/src/main/react/app/routes/builder/canvas/nodetypes/frank-node.tsx
+++ b/src/main/react/app/routes/builder/canvas/nodetypes/frank-node.tsx
@@ -326,7 +326,7 @@ export default function FrankNode(properties: NodeProps<FrankNode>) {
   )
 }
 
-export function ResizeIcon() {
+export function ResizeIcon({ color = '#999999' }: Readonly<{ color?: string }>) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -334,7 +334,7 @@ export function ResizeIcon() {
       height="20"
       viewBox="0 0 24 24"
       strokeWidth="1"
-      stroke="#999999"
+      stroke={color}
       strokeLinecap="round"
       className={'absolute right-[5px] bottom-[5px]'}
     >

--- a/src/main/react/app/routes/builder/canvas/nodetypes/group-node.tsx
+++ b/src/main/react/app/routes/builder/canvas/nodetypes/group-node.tsx
@@ -1,0 +1,28 @@
+import type { NodeProps, Node } from '@xyflow/react'
+
+export type GroupNode = Node<{
+  label: string
+  width: number
+  height: number
+}>
+
+export default function GroupNodeComponent({ data, selected }: NodeProps<GroupNode>) {
+  return (
+    <div
+      className={`pointer-events-none cursor-default rounded border bg-pink-300/25 ${selected ? 'ring-2 ring-blue-500' : ''}`}
+      style={{
+        width: data.width,
+        height: data.height,
+      }}
+    >
+      <div
+        className="drag-handle cursor-move bg-pink-300 px-2 py-1 text-sm font-bold"
+        style={{
+          pointerEvents: 'all',
+        }}
+      >
+        {data.label}
+      </div>
+    </div>
+  )
+}

--- a/src/main/react/app/routes/builder/canvas/nodetypes/group-node.tsx
+++ b/src/main/react/app/routes/builder/canvas/nodetypes/group-node.tsx
@@ -1,4 +1,6 @@
-import type { NodeProps, Node } from '@xyflow/react'
+import { type NodeProps, type Node, NodeResizeControl } from '@xyflow/react'
+import { useState } from 'react'
+import { ResizeIcon } from '~/routes/builder/canvas/nodetypes/frank-node'
 
 export type GroupNode = Node<{
   label: string
@@ -7,22 +9,111 @@ export type GroupNode = Node<{
 }>
 
 export default function GroupNodeComponent({ data, selected }: NodeProps<GroupNode>) {
+  const [dimensions, setDimensions] = useState({
+    width: data.width,
+    height: data.height,
+  })
+  const [isEditing, setIsEditing] = useState(false)
+  const [label, setLabel] = useState(data.label)
+
+  const handleBlur = () => setIsEditing(false)
+  const handleClick = () => setIsEditing(true)
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      handleBlur()
+    }
+  }
+
   return (
-    <div
-      className={`pointer-events-none cursor-default rounded border bg-pink-300/25 ${selected ? 'ring-2 ring-blue-500' : ''}`}
-      style={{
-        width: data.width,
-        height: data.height,
-      }}
-    >
+    <>
+      <NodeResizeControl
+        onResize={(event, resizeData) => {
+          setDimensions({
+            width: resizeData.width,
+            height: resizeData.height,
+          })
+        }}
+        style={{ background: 'transparent', border: 'none' }}
+      >
+        <ResizeIcon color="black" />
+      </NodeResizeControl>
       <div
-        className="drag-handle cursor-move bg-pink-300 px-2 py-1 text-sm font-bold"
+        className="pointer-events-none cursor-default rounded border bg-pink-300/25"
         style={{
-          pointerEvents: 'all',
+          width: dimensions.width,
+          height: dimensions.height,
         }}
       >
-        {data.label}
+        <div
+          className="drag-handle relative max-h-1/2 cursor-move bg-pink-300 p-1"
+          style={{
+            pointerEvents: 'all',
+          }}
+        >
+          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
+            <HamburgerMenu />
+          </div>
+          <div className="flex max-w-1/2 gap-1 px-2 py-1 text-sm font-bold">
+            {isEditing ? (
+              <input
+                type="text"
+                value={label}
+                onChange={(event) => setLabel(event.target.value)}
+                onKeyDown={handleKeyDown}
+                onBlur={handleBlur}
+                autoFocus
+                className="nodrag rounded border px-1 text-sm"
+              />
+            ) : (
+              <>
+                <div className="cursor-pointer" onClick={handleClick}>
+                  {label}
+                </div>
+                <div onClick={handleClick} className="flex-shrink-0 cursor-pointer self-start">
+                  <PenIcon />
+                </div>
+              </>
+            )}
+          </div>
+        </div>
       </div>
-    </div>
+    </>
+  )
+}
+
+function HamburgerMenu() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className="ml-2 h-4 w-4"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2}
+    >
+      <line x1="4" y1="6" x2="20" y2="6" strokeLinecap="round" strokeLinejoin="round" />
+      <line x1="4" y1="12" x2="20" y2="12" strokeLinecap="round" strokeLinejoin="round" />
+      <line x1="4" y1="18" x2="20" y2="18" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+function PenIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className="ml-2 h-4 w-4"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M11 5H6a2 2 0 00-2 2v11.5A1.5 1.5 0 005.5 20H17a2 2 0 002-2v-5M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z"
+      />
+    </svg>
   )
 }


### PR DESCRIPTION
When a multitude of nodes are selected, hitting 'G' will group them together

- All nodes selected not yet in a group -> they are put into the same group
- All nodes selected already part of the same group -> they get degrouped
- A part of selected nodes is part of a group -> outsider nodes get added to this group
- Two or more groups fully selected -> they get merged into one single large group

Closes #56 