### PR TITLE
NodeContextMenu is now always toggled on node selection

### DIFF
--- a/src/main/frontend/app/routes/studio/context/element-hover-card.tsx
+++ b/src/main/frontend/app/routes/studio/context/element-hover-card.tsx
@@ -1,4 +1,4 @@
-import {useFFDoc, useJavadocTransform} from "@frankframework/doc-library-react";
+import { useFFDoc, useJavadocTransform } from '@frankframework/doc-library-react'
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import type { ElementDetails } from '~/types/ff-doc.types'

--- a/src/main/frontend/app/routes/studio/studio.tsx
+++ b/src/main/frontend/app/routes/studio/studio.tsx
@@ -7,7 +7,7 @@ import NodeContext from '~/routes/studio/context/node-context'
 import useNodeContextStore from '~/stores/node-context-store'
 import SidebarContentClose from '~/components/sidebars-layout/sidebar-content-close'
 import SidebarHeader from '~/components/sidebars-layout/sidebar-header'
-import { SidebarSide } from '~/components/sidebars-layout/sidebar-layout-store'
+import { SidebarSide, useSidebarStore } from '~/components/sidebars-layout/sidebar-layout-store'
 import SidebarLayout from '~/components/sidebars-layout/sidebar-layout'
 import useTabStore from '~/stores/tab-store'
 import { useShallow } from 'zustand/react/shallow'
@@ -19,6 +19,7 @@ import Button from '~/components/inputs/button'
 
 export default function Studio() {
   const project = useProjectStore((state) => state.project)
+  const setVisibility = useSidebarStore((state) => state.setVisibility)
   const [showNodeContext, setShowNodeContext] = useState(false)
   const { nodeId, editingSubtype } = useNodeContextStore(
     useShallow((s) => ({ nodeId: s.nodeId, editingSubtype: s.editingSubtype })),
@@ -29,6 +30,16 @@ export default function Studio() {
       activeTab: state.activeTab,
       activeTabPath: state.activeTab ? state.tabs[state.activeTab]?.configurationPath : undefined,
     })),
+  )
+
+  const handleShowNodeContext = useCallback(
+    (visible: boolean) => {
+      setShowNodeContext(visible)
+      if (visible) {
+        setVisibility('studio', SidebarSide.RIGHT, true)
+      }
+    },
+    [setVisibility],
   )
 
   const handleOpenInEditor = useCallback(() => {
@@ -66,7 +77,7 @@ export default function Studio() {
                 Open in Editor
               </Button>
             </div>
-            <Flow showNodeContextMenu={setShowNodeContext} />
+            <Flow showNodeContextMenu={handleShowNodeContext} />
           </>
         ) : (
           <div className="text-muted-foreground flex h-full flex-col items-center justify-center p-8 text-center">
@@ -84,7 +95,11 @@ export default function Studio() {
           side={SidebarSide.RIGHT}
           title={showNodeContext ? `Edit ${editingSubtype ?? 'node'}` : 'Palette'}
         />
-        {showNodeContext ? <NodeContext nodeId={nodeId} setShowNodeContext={setShowNodeContext} /> : <StudioContext />}
+        {showNodeContext ? (
+          <NodeContext nodeId={nodeId} setShowNodeContext={handleShowNodeContext} />
+        ) : (
+          <StudioContext />
+        )}
       </>
     </SidebarLayout>
   )


### PR DESCRIPTION
whether the menu is folded in or out