### PR TITLE
Deprecated popover bug and structure title updates

### DIFF
--- a/src/main/frontend/app/routes/editor/editor.tsx
+++ b/src/main/frontend/app/routes/editor/editor.tsx
@@ -27,6 +27,7 @@ import { refreshOpenDiffs } from '~/services/git-service'
 import { findAdapterIndexAtOffset, findAdaptersInXml, lineToOffset, normalizeFrankElements } from './xml-utils'
 import { useSettingsStore } from '~/stores/settings-store'
 import { toProjectRelativePath } from '~/utils/path-utils'
+import SidebarHeader from '~/components/sidebars-layout/sidebar-header'
 
 type LeftTab = 'files' | 'git'
 type SaveStatus = 'idle' | 'saving' | 'saved'
@@ -472,9 +473,9 @@ export default function CodeEditor() {
   return (
     <SidebarLayout name="editor">
       <>
-        <div className="flex h-12 items-center justify-between px-4">
-          <SidebarClose side={SidebarSide.LEFT} />
-          <div className="border-border flex overflow-hidden rounded border text-sm">
+        <div className="flex h-12 items-center justify-between pr-4">
+          <SidebarHeader side={SidebarSide.LEFT} title="Files" />
+          <div className="border-border ml-auto flex overflow-hidden rounded border text-sm">
             <button
               onClick={() => setLeftTab('files')}
               className={clsx(

--- a/src/main/frontend/app/routes/studio/context/deprecated-list-popover.tsx
+++ b/src/main/frontend/app/routes/studio/context/deprecated-list-popover.tsx
@@ -1,12 +1,21 @@
+import { createPortal } from 'react-dom'
+
 export interface DeprecatedInfo {
   since?: string
   forRemoval?: boolean
   description?: string
 }
 
-export function DeprecatedListPopover({ deprecated }: { deprecated: DeprecatedInfo }) {
-  return (
-    <div className="bg-background text-foreground pointer-events-none absolute top-1/2 right-10 ml-2 w-64 -translate-y-1/2 scale-95 rounded-md border border-red-400 p-3 text-xs opacity-0 shadow-lg transition-all group-hover:scale-100 group-hover:opacity-100">
+export function DeprecatedListPopover({ deprecated, anchorRect }: { deprecated: DeprecatedInfo; anchorRect: DOMRect }) {
+  return createPortal(
+    <div
+      className="bg-background text-foreground fixed z-[9999] w-64 rounded-md border border-red-400 p-3 text-xs shadow-lg transition-all"
+      style={{
+        top: anchorRect.top + anchorRect.height / 2,
+        left: anchorRect.left - 260,
+        transform: 'translateY(-50%)',
+      }}
+    >
       <h3 className="mb-2 font-bold text-red-600">Deprecated</h3>
 
       <ul className="space-y-1">
@@ -26,6 +35,7 @@ export function DeprecatedListPopover({ deprecated }: { deprecated: DeprecatedIn
           <li className="text-muted-foreground border-border rounded-md border p-2">{deprecated.description}</li>
         )}
       </ul>
-    </div>
+    </div>,
+    document.body,
   )
 }

--- a/src/main/frontend/app/routes/studio/context/sorted-elements.tsx
+++ b/src/main/frontend/app/routes/studio/context/sorted-elements.tsx
@@ -6,7 +6,7 @@ import useNodeContextStore from '~/stores/node-context-store'
 import type { ElementDetails } from '@frankframework/doc-library-core'
 import { getElementTypeFromName } from '../node-translator-module'
 import DangerIcon from '../../../../icons/solar/Danger Triangle.svg?react'
-import { DeprecatedListPopover } from './deprecated-list-popover'
+import { DeprecatedListPopover, type DeprecatedInfo } from './deprecated-list-popover'
 import ElementHoverCard from './element-hover-card'
 
 interface Properties {
@@ -22,6 +22,8 @@ export default function SortedElements({ type, items, onDragStart, searchTerm }:
   const { setDraggedName } = useNodeContextStore((state) => state)
   const [hoveredRect, setHoveredRect] = useState<DOMRect | null>(null)
   const [hoveredElement, setHoveredElement] = useState<ElementDetails | null>(null)
+  const [deprecatedRect, setDeprecatedRect] = useState<DOMRect | null>(null)
+  const [deprecatedHovered, setDeprecatedHovered] = useState<DeprecatedInfo | null>(null)
   const [lockedElement, setLockedElement] = useState<ElementDetails | null>(null)
 
   const toggleExpansion = () => {
@@ -93,9 +95,22 @@ export default function SortedElements({ type, items, onDragStart, searchTerm }:
 
                 {/* Right: deprecated icon */}
                 {value.deprecated && (
-                  <div className="group relative ml-2 flex-shrink-0">
+                  <div
+                    className="ml-2 flex-shrink-0"
+                    onMouseEnter={(event) => {
+                      const rect = event.currentTarget.getBoundingClientRect()
+                      setDeprecatedRect(rect)
+                      setDeprecatedHovered(value.deprecated!)
+                    }}
+                    onMouseLeave={() => {
+                      setDeprecatedRect(null)
+                      setDeprecatedHovered(null)
+                    }}
+                  >
                     <DangerIcon />
-                    <DeprecatedListPopover deprecated={value.deprecated} />
+                    {deprecatedRect && deprecatedHovered && (
+                      <DeprecatedListPopover deprecated={deprecatedHovered} anchorRect={deprecatedRect} />
+                    )}
                   </div>
                 )}
               </li>

--- a/src/main/frontend/app/routes/studio/studio.tsx
+++ b/src/main/frontend/app/routes/studio/studio.tsx
@@ -54,7 +54,7 @@ export default function Studio() {
   return (
     <SidebarLayout name="studio">
       <>
-        <SidebarHeader side={SidebarSide.LEFT} title="Structure" />
+        <SidebarHeader side={SidebarSide.LEFT} title="Adapter" />
         <StudioFileStructure />
       </>
       <>


### PR DESCRIPTION
- Fixed an issue where the deprecated popover in the palette did not render on top of the canvas
- Updated the titles of the left side bar in the studio and editor to 'Adapter' and 'Files' respectively

Closes #283, Closes #363 