### PR TITLE
Add key prop to Allotment component for improved rendering

### DIFF
--- a/src/main/frontend/app/components/sidebars-layout/sidebar-layout.tsx
+++ b/src/main/frontend/app/components/sidebars-layout/sidebar-layout.tsx
@@ -20,7 +20,7 @@ export default function SidebarLayout({ children, name }: Readonly<SidebarLayout
 
   return (
     <SidebarContext.Provider value={name}>
-      <Allotment onVisibleChange={handleVisibilityChange}>
+      <Allotment key={name} onVisibleChange={handleVisibilityChange}>
         <Allotment.Pane
           snap
           minSize={200}


### PR DESCRIPTION
This prevents the crash because Allotment's internal pane index array is never left in a partially-updated state