### PR TITLE
Enhanced active tab handling to prevent file reveal for diff tabs

### DIFF
--- a/src/main/frontend/app/components/file-structure/editor-file-structure.tsx
+++ b/src/main/frontend/app/components/file-structure/editor-file-structure.tsx
@@ -57,6 +57,7 @@ export default function EditorFileStructure() {
   const removeTab = useEditorTabStore((state) => state.removeTab)
   const removeTabAndSelectFallback = useEditorTabStore((state) => state.removeTabAndSelectFallback)
   const activeTabFilePath = useEditorTabStore((state) => state.activeTabFilePath)
+  const activeTab = useEditorTabStore((state) => state.tabs[state.activeTabFilePath])
 
   const [dataProvider, setDataProvider] = useState<EditorFilesDataProvider | null>(null)
   const [selectedItemId, setSelectedItemId] = useState<TreeItemIndex | null>(null)
@@ -159,6 +160,7 @@ export default function EditorFileStructure() {
 
   const revealActiveFile = useCallback(async () => {
     if (!dataProvider || !activeTabFilePath || !rootPath || !tree.current) return
+    if (activeTab?.type === 'diff') return
 
     const itemId = toTreeItemId(activeTabFilePath, rootPath)
 
@@ -168,7 +170,7 @@ export default function EditorFileStructure() {
     }
 
     selectAndReveal(tree.current, itemId)
-  }, [dataProvider, activeTabFilePath, rootPath])
+  }, [dataProvider, activeTabFilePath, rootPath, activeTab])
 
   useShortcut({
     'explorer.new-file': () => triggerExplorerAction(editorContextMenu.handleNewFile, false),
@@ -433,7 +435,7 @@ export default function EditorFileStructure() {
         <div className="flex items-center gap-0.5">
           <IconButton
             title="Open File Tree to Active Tab"
-            disabled={!activeTabFilePath || isActiveItemVisible}
+            disabled={!activeTabFilePath || isActiveItemVisible || activeTab?.type === 'diff'}
             onClick={() => void revealActiveFile()}
           >
             <ListDown className="fill-foreground-muted group-hover:fill-foreground h-5 w-5" />


### PR DESCRIPTION
Now the file reveal button is disabled when a diff tab is open
<img width="3836" height="926" alt="image" src="https://github.com/user-attachments/assets/8fab513c-49bf-4d56-a9a5-4e0ef9e362d9" />
