### PR TITLE
Refactored SSE watcher to manage multiple event sources

### DIFF
--- a/src/main/frontend/app/hooks/use-file-watcher.ts
+++ b/src/main/frontend/app/hooks/use-file-watcher.ts
@@ -1,6 +1,14 @@
 import { useEffect, useRef } from 'react'
 import { apiUrl } from '~/utils/api'
 
+interface WatcherEntry {
+  source: EventSource
+  handlers: Set<() => void>
+  closeTimer: ReturnType<typeof setTimeout> | null
+}
+
+const watchers = new Map<string, WatcherEntry>()
+
 function useSseWatcher(url: string | null, onFileChange: () => void) {
   const callbackRef = useRef(onFileChange)
   callbackRef.current = onFileChange
@@ -8,14 +16,35 @@ function useSseWatcher(url: string | null, onFileChange: () => void) {
   useEffect(() => {
     if (!url) return
 
-    const eventSource = new EventSource(url)
+    let entry = watchers.get(url)
 
-    eventSource.addEventListener('file-change', () => {
-      callbackRef.current()
-    })
+    if (entry) {
+      if (entry.closeTimer !== null) {
+        clearTimeout(entry.closeTimer)
+        entry.closeTimer = null
+      }
+    } else {
+      const source = new EventSource(url)
+      entry = { source, handlers: new Set(), closeTimer: null }
+      watchers.set(url, entry)
+    }
+
+    const handler = () => callbackRef.current()
+    entry.handlers.add(handler)
+    entry.source.addEventListener('file-change', handler)
+
+    const currentEntry = entry
 
     return () => {
-      eventSource.close()
+      currentEntry.source.removeEventListener('file-change', handler)
+      currentEntry.handlers.delete(handler)
+
+      if (currentEntry.handlers.size === 0) {
+        currentEntry.closeTimer = setTimeout(() => {
+          currentEntry.source.close()
+          watchers.delete(url)
+        }, 100)
+      }
     }
   }, [url])
 }

--- a/src/main/frontend/app/hooks/use-file-watcher.ts
+++ b/src/main/frontend/app/hooks/use-file-watcher.ts
@@ -9,7 +9,7 @@ interface WatcherEntry {
 
 const watchers = new Map<string, WatcherEntry>()
 
-function useSseWatcher(url: string | null, onFileChange: () => void) {
+function useSseWatcher(url: string | null, onFileChange?: () => void) {
   const callbackRef = useRef(onFileChange)
   callbackRef.current = onFileChange
 
@@ -29,7 +29,7 @@ function useSseWatcher(url: string | null, onFileChange: () => void) {
       watchers.set(url, entry)
     }
 
-    const handler = () => callbackRef.current()
+    const handler = () => callbackRef.current?.()
     entry.handlers.add(handler)
     entry.source.addEventListener('file-change', handler)
 
@@ -49,7 +49,7 @@ function useSseWatcher(url: string | null, onFileChange: () => void) {
   }, [url])
 }
 
-export function useFileWatcher(projectName: string | null | undefined, onFileChange: () => void) {
+export function useFileWatcher(projectName: string | null | undefined, onFileChange?: () => void) {
   const url = projectName ? apiUrl(`/projects/${projectName}/watch`) : null
   useSseWatcher(url, onFileChange)
 }

--- a/src/main/frontend/app/routes/app-layout.tsx
+++ b/src/main/frontend/app/routes/app-layout.tsx
@@ -8,9 +8,13 @@ import { openProject } from '~/services/project-service'
 import LoadingSpinner from '~/components/loading-spinner'
 import { apiUrl } from '~/utils/api'
 import { useShortcutListener } from '~/hooks/use-shortcut-listener'
+import { useFileWatcher } from '~/hooks/use-file-watcher'
 
 export default function AppLayout() {
   useShortcutListener()
+
+  const projectName = useProjectStore((state) => state.project?.name)
+  useFileWatcher(projectName)
 
   const [restoring, setRestoring] = useState(!!getStoredProjectRootPath())
 


### PR DESCRIPTION
Before every component was calling useSseWatcher with the same URL would open its own EventSource connection. When the component unmounted, it would close it immediately and this continued.

Now if two components watch the same URL, they reuse the same EventSource. Each registers its own handler on that shared connection. The connection only closes when the last subscriber unmounts
