### PR TITLE
Added selected state to file hunk management for improved selection handling

### DIFF
--- a/src/main/frontend/app/components/git/git-changes.tsx
+++ b/src/main/frontend/app/components/git/git-changes.tsx
@@ -60,19 +60,14 @@ function FileSection({
             const dirPath = file.includes('/') ? file.slice(0, file.lastIndexOf('/')) : ''
 
             const hunkState = fileHunkStates[file]
-            let checkboxChecked = false
-            let checkboxIndeterminate = false
+            const totalHunks = hunkState?.totalHunks ?? 0
+            const selectedCount = hunkState?.selectedHunks.size ?? 0
+            const allHunksSelected = totalHunks > 0 && selectedCount === totalHunks
+            const someHunksSelected = totalHunks > 0 && selectedCount > 0
+            const fileSelectedWithNoHunks = totalHunks === 0 && (hunkState?.selected ?? false)
 
-            if (hunkState && hunkState.totalHunks > 0) {
-              const selectedCount = hunkState.selectedHunks.size
-              if (selectedCount === hunkState.totalHunks) {
-                checkboxChecked = true
-              } else if (selectedCount > 0) {
-                checkboxIndeterminate = true
-              }
-            } else if (hunkState && hunkState.totalHunks === 0 && hunkState.selected) {
-              checkboxChecked = true
-            }
+            const checkboxChecked = allHunksSelected || fileSelectedWithNoHunks
+            const checkboxIndeterminate = someHunksSelected && !allHunksSelected
 
             return (
               <div

--- a/src/main/frontend/app/components/git/git-changes.tsx
+++ b/src/main/frontend/app/components/git/git-changes.tsx
@@ -70,6 +70,8 @@ function FileSection({
               } else if (selectedCount > 0) {
                 checkboxIndeterminate = true
               }
+            } else if (hunkState && hunkState.totalHunks === 0 && hunkState.selected) {
+              checkboxChecked = true
             }
 
             return (

--- a/src/main/frontend/app/components/git/git-panel.tsx
+++ b/src/main/frontend/app/components/git/git-panel.tsx
@@ -92,18 +92,34 @@ export default function GitPanel({ projectName, hasStoredToken }: GitPanelProps)
   const handleToggleFile = useCallback(
     async (filePath: string) => {
       const hunkState = useGitStore.getState().fileHunkStates[filePath]
-      if (!hunkState || hunkState.totalHunks === 0) {
+      if (!hunkState) {
         await handleSelectFile(filePath)
       }
 
       const updatedState = useGitStore.getState().fileHunkStates[filePath]
+
+      if (!updatedState) {
+        initFileHunks(filePath, 0)
+        selectAllFileHunks(filePath)
+        return
+      }
+
+      if (updatedState.totalHunks === 0) {
+        if (updatedState.selected) {
+          clearFileHunks(filePath)
+        } else {
+          selectAllFileHunks(filePath)
+        }
+        return
+      }
+
       if (updatedState.selectedHunks.size === updatedState.totalHunks) {
         clearFileHunks(filePath)
       } else {
         selectAllFileHunks(filePath)
       }
     },
-    [handleSelectFile, clearFileHunks, selectAllFileHunks],
+    [handleSelectFile, initFileHunks, clearFileHunks, selectAllFileHunks],
   )
 
   const handleCommit = useCallback(async () => {
@@ -113,8 +129,11 @@ export default function GitPanel({ projectName, hasStoredToken }: GitPanelProps)
       const allHunkStates = useGitStore.getState().fileHunkStates
 
       for (const [filePath, hunkState] of Object.entries(allHunkStates)) {
-        if (hunkState.selectedHunks.size === 0) continue
-        await (hunkState.selectedHunks.size === hunkState.totalHunks
+        const isZeroHunkSelected = hunkState.totalHunks === 0 && hunkState.selected
+
+        if (hunkState.selectedHunks.size === 0 && !isZeroHunkSelected) continue
+
+        await (isZeroHunkSelected || hunkState.selectedHunks.size === hunkState.totalHunks
           ? stageFile(projectName, filePath)
           : stageHunks(projectName, filePath, [...hunkState.selectedHunks]))
       }
@@ -175,7 +194,9 @@ export default function GitPanel({ projectName, hasStoredToken }: GitPanelProps)
     }
   }, [projectName, token, refreshStatus])
 
-  const hasSelectedChunks = Object.values(fileHunkStates).some((s) => s.selectedHunks.size > 0)
+  const hasSelectedChunks = Object.values(fileHunkStates).some(
+    (s) => s.selectedHunks.size > 0 || (s.totalHunks === 0 && s.selected),
+  )
 
   return (
     <div className="flex h-full flex-col overflow-hidden">

--- a/src/main/frontend/app/components/git/git-panel.tsx
+++ b/src/main/frontend/app/components/git/git-panel.tsx
@@ -195,7 +195,7 @@ export default function GitPanel({ projectName, hasStoredToken }: GitPanelProps)
   }, [projectName, token, refreshStatus])
 
   const hasSelectedChunks = Object.values(fileHunkStates).some(
-    (s) => s.selectedHunks.size > 0 || (s.totalHunks === 0 && s.selected),
+    (state) => state.selectedHunks.size > 0 || (state.totalHunks === 0 && state.selected),
   )
 
   return (

--- a/src/main/frontend/app/stores/git-store.ts
+++ b/src/main/frontend/app/stores/git-store.ts
@@ -43,7 +43,7 @@ export const useGitStore = create<GitStoreState>((set, get) => ({
     set((state) => ({
       fileHunkStates: {
         ...state.fileHunkStates,
-        [file]: { selectedHunks: new Set(), totalHunks },
+        [file]: { selectedHunks: new Set(), totalHunks, selected: false },
       },
     }))
   },
@@ -73,7 +73,7 @@ export const useGitStore = create<GitStoreState>((set, get) => ({
     set((s) => ({
       fileHunkStates: {
         ...s.fileHunkStates,
-        [file]: { ...state, selectedHunks: all },
+        [file]: { ...state, selectedHunks: all, selected: true },
       },
     }))
   },
@@ -84,7 +84,7 @@ export const useGitStore = create<GitStoreState>((set, get) => ({
     set((s) => ({
       fileHunkStates: {
         ...s.fileHunkStates,
-        [file]: { ...state, selectedHunks: new Set() },
+        [file]: { ...state, selectedHunks: new Set(), selected: false },
       },
     }))
   },

--- a/src/main/frontend/app/types/git.types.ts
+++ b/src/main/frontend/app/types/git.types.ts
@@ -52,4 +52,5 @@ export interface GitPullResult {
 export interface FileHunkState {
   selectedHunks: Set<number>
   totalHunks: number
+  selected: boolean
 }


### PR DESCRIPTION
Previously it was not able to make a commit with 0 hunks (code blocks) so it was not possible to push empty files for example. Now it is fixed.
<img width="3830" height="1980" alt="image" src="https://github.com/user-attachments/assets/59c3daff-47f3-4913-8f1f-30f64c08f95e" />
<img width="2297" height="412" alt="image" src="https://github.com/user-attachments/assets/84d70da2-c329-4237-877a-c052873db7c7" />
<img width="3819" height="1185" alt="image" src="https://github.com/user-attachments/assets/b8d4bc21-43fa-4a1e-ad20-f1cbb3ac94aa" />
