### PR TITLE
Solved Cookie token creation for requests

### DIFF
--- a/src/main/frontend/.gitignore
+++ b/src/main/frontend/.gitignore
@@ -9,3 +9,5 @@
 /.env
 /.env.production
 /.env.development
+
+/build

--- a/src/main/frontend/.gitignore
+++ b/src/main/frontend/.gitignore
@@ -9,5 +9,3 @@
 /.env
 /.env.production
 /.env.development
-
-/build

--- a/src/main/frontend/app/utils/api.ts
+++ b/src/main/frontend/app/utils/api.ts
@@ -1,7 +1,5 @@
-import variables from '../../environment/environment'
-
 export function apiUrl(path: string): string {
-  return `${variables.apiBaseUrl}/api${path}`
+  return `/api${path}`
 }
 
 const getAnonymousSessionId = () => {

--- a/src/main/frontend/environment/base.ts
+++ b/src/main/frontend/environment/base.ts
@@ -1,9 +1,0 @@
-export interface EnvironmentVariables {
-  apiBaseUrl: string
-}
-
-const base: EnvironmentVariables = {
-  apiBaseUrl: '',
-}
-
-export default base

--- a/src/main/frontend/environment/development.ts
+++ b/src/main/frontend/environment/development.ts
@@ -1,8 +1,0 @@
-import base, { type EnvironmentVariables } from './base'
-
-const development: EnvironmentVariables = {
-  ...base,
-  apiBaseUrl: '',
-}
-
-export default development

--- a/src/main/frontend/environment/development.ts
+++ b/src/main/frontend/environment/development.ts
@@ -2,7 +2,7 @@ import base, { type EnvironmentVariables } from './base'
 
 const development: EnvironmentVariables = {
   ...base,
-  apiBaseUrl: 'http://localhost:8080',
+  apiBaseUrl: '',
 }
 
 export default development

--- a/src/main/frontend/environment/environment.ts
+++ b/src/main/frontend/environment/environment.ts
@@ -1,9 +1,0 @@
-import development from './development'
-import production from './production'
-import type { EnvironmentVariables } from './base'
-
-const environment = process.env.NODE_ENV
-
-const variables: EnvironmentVariables = environment === 'development' ? development : production
-
-export default variables

--- a/src/main/frontend/environment/production.ts
+++ b/src/main/frontend/environment/production.ts
@@ -1,7 +1,0 @@
-import base, { type EnvironmentVariables } from './base'
-
-const production: EnvironmentVariables = {
-  ...base,
-}
-
-export default production

--- a/src/main/frontend/vite.config.ts
+++ b/src/main/frontend/vite.config.ts
@@ -28,5 +28,8 @@ export default defineConfig({
   },
   server: {
     port: 3000,
+    proxy: {
+      '/api': 'http://localhost:8080',
+    },
   },
 })

--- a/src/main/java/org/frankframework/flow/common/config/CsrfCookieFilter.java
+++ b/src/main/java/org/frankframework/flow/common/config/CsrfCookieFilter.java
@@ -1,0 +1,32 @@
+package org.frankframework.flow.common.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.jspecify.annotations.NonNull;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Forces the deferred {@link CsrfToken} to load on every request so the XSRF-TOKEN cookie is
+ * written. Otherwise the cookie is only minted when something reads the token, leaving a SPA with no
+ * token to echo back as X-XSRF-TOKEN.
+ */
+public class CsrfCookieFilter extends OncePerRequestFilter {
+
+	@Override
+	protected void doFilterInternal(
+			@NonNull HttpServletRequest request,
+			@NonNull HttpServletResponse response,
+			@NonNull FilterChain filterChain
+	) throws ServletException, IOException {
+		CsrfToken csrfToken = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
+		if (csrfToken != null) {
+			csrfToken.getToken();
+		}
+
+		filterChain.doFilter(request, response);
+	}
+}

--- a/src/main/java/org/frankframework/flow/common/config/SecurityChainConfigurer.java
+++ b/src/main/java/org/frankframework/flow/common/config/SecurityChainConfigurer.java
@@ -17,6 +17,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.annotation.web.configurers.LogoutConfigurer;
@@ -50,23 +51,11 @@ public class SecurityChainConfigurer implements ApplicationContextAware, Environ
 	public SecurityFilterChain configureChain(IAuthenticator authenticator, HttpSecurity http) throws Exception {
 		configureAuthenticator(authenticator);
 		http.headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin));
-		http.csrf(csrf -> {
-			if (csrfEnabled) {
-				csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse());
-				csrf.csrfTokenRequestHandler(new SpaCsrfTokenRequestHandler());
-				return;
-			}
-			csrf.disable();
-		});
+		configureCsrf(http);
 		http.securityMatcher(AnyRequestMatcher.INSTANCE);
 		http.formLogin(FormLoginConfigurer::disable);
 		http.logout(LogoutConfigurer::disable);
 		http.sessionManagement(management -> management.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED));
-
-		if (csrfEnabled) {
-			http.addFilterAfter(new CsrfCookieFilter(), CsrfFilter.class);
-		}
-
 		return authenticator.configureHttpSecurity(http);
 	}
 
@@ -80,5 +69,19 @@ public class SecurityChainConfigurer implements ApplicationContextAware, Environ
 		ServletConfiguration servletConfig = new ServletConfiguration();
 		servletConfig.setUrlMapping("/*");
 		authenticator.registerServlet(servletConfig);
+	}
+
+	private void configureCsrf(HttpSecurity http) {
+		if (!csrfEnabled) {
+			http.csrf(AbstractHttpConfigurer::disable);
+			return;
+		}
+
+		http.csrf(csrf -> {
+			csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse());
+			csrf.csrfTokenRequestHandler(new SpaCsrfTokenRequestHandler());
+		});
+
+		http.addFilterAfter(new CsrfCookieFilter(), CsrfFilter.class);
 	}
 }

--- a/src/main/java/org/frankframework/flow/common/config/SecurityChainConfigurer.java
+++ b/src/main/java/org/frankframework/flow/common/config/SecurityChainConfigurer.java
@@ -23,6 +23,7 @@ import org.springframework.security.config.annotation.web.configurers.LogoutConf
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.security.web.util.matcher.AnyRequestMatcher;
 
 @Configuration
@@ -61,6 +62,11 @@ public class SecurityChainConfigurer implements ApplicationContextAware, Environ
 		http.formLogin(FormLoginConfigurer::disable);
 		http.logout(LogoutConfigurer::disable);
 		http.sessionManagement(management -> management.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED));
+
+		if (csrfEnabled) {
+			http.addFilterAfter(new CsrfCookieFilter(), CsrfFilter.class);
+		}
+
 		return authenticator.configureHttpSecurity(http);
 	}
 


### PR DESCRIPTION
Server (CsrfCookieFilter)  →  Set-Cookie: XSRF-TOKEN  →  browser stores it
 browser (api.ts)   →  reads cookie, sets header  →  X-XSRF-TOKEN on POST
 Server (CsrfFilter)   →  header == cookie?   →  yes → allow

 The reason the filter was needed is that without it the server never issued the cookie in the first place, so the frontend had nothing to read and copy onto the request. The filter supplies the token (via a response cookie) and the frontend is what actually attaches it to requests.

This also directly solved issue #548 
