### PR TITLE
Enhance configuration file handling, validate filename input and adjust paths

### DIFF
--- a/src/main/frontend/app/actions/navigationActions.ts
+++ b/src/main/frontend/app/actions/navigationActions.ts
@@ -1,6 +1,7 @@
 import { type NavigateFunction } from 'react-router'
 import useTabStore from '~/stores/tab-store'
 import useEditorTabStore from '~/stores/editor-tab-store'
+import { getBaseName } from '~/utils/path-utils'
 
 export function openInStudio(
   navigate: NavigateFunction,
@@ -46,7 +47,7 @@ export function openInEditorAtElement(
   { subtype, filepath, name }: { subtype: string; filepath: string; name?: string },
 ) {
   const editorStore = useEditorTabStore.getState()
-  const fileName = filepath.split(/[/\\]/).pop() ?? filepath
+  const fileName = getBaseName(filepath)
 
   if (!editorStore.getTab(filepath)) {
     editorStore.setTabData(filepath, {

--- a/src/main/frontend/app/components/directory-picker/directory-picker.tsx
+++ b/src/main/frontend/app/components/directory-picker/directory-picker.tsx
@@ -5,6 +5,7 @@ import { filesystemService } from '~/services/filesystem-service'
 import type { FilesystemEntry } from '~/types/filesystem.types'
 import { ApiError } from '~/utils/api'
 import { useDirectoryWatcher } from '~/hooks/use-file-watcher'
+import { normalizePath } from '~/utils/path-utils'
 import Button from '../inputs/button'
 import CloseButton from '../inputs/close-button'
 
@@ -36,9 +37,9 @@ export default function DirectoryPicker({
     setIsCreatingFolder(false)
     try {
       const result = await filesystemService.browse(path)
-      setEntries(result.entries)
-      setCurrentPath(result.resolvedPath)
-      setParentPath(result.parentPath)
+      setEntries(result.entries.map((entry) => ({ ...entry, path: normalizePath(entry.path) })))
+      setCurrentPath(normalizePath(result.resolvedPath))
+      setParentPath(normalizePath(result.parentPath))
     } catch (error) {
       if (error instanceof ApiError && error.httpCode === 403) {
         setError('Access denied')

--- a/src/main/frontend/app/components/file-structure/name-input-dialog.tsx
+++ b/src/main/frontend/app/components/file-structure/name-input-dialog.tsx
@@ -22,6 +22,11 @@ export const CONFIGURATION_NAME_PATTERNS: Record<string, RegExp> = {
 
 export const FOLDER_OR_ADAPTER_NAME_PATTERNS: Record<string, RegExp> = BASE_NAME_PATTERNS
 
+export const PROJECT_NAME_PATTERNS: Record<string, RegExp> = {
+  ...BASE_NAME_PATTERNS,
+  'Cannot have a file extension': /^(?!.*\.[^.\\/]+$).*$/,
+}
+
 type NameInputDialogProps = {
   title: string
   initialValue?: string

--- a/src/main/frontend/app/components/file-structure/studio-file-structure.tsx
+++ b/src/main/frontend/app/components/file-structure/studio-file-structure.tsx
@@ -47,8 +47,7 @@ function studioTabItemId(activeTab: string, dataProvider: StudioFilesDataProvide
   const lastSep = rest.lastIndexOf('::')
   const adapterName = lastSep === -1 ? rest : rest.slice(0, lastSep)
   const position = lastSep === -1 ? '0' : rest.slice(lastSep + 2)
-  const rootPath = dataProvider.getRootPath().replace(/[/\\]$/, '')
-  return `${toTreeItemId(configPath, rootPath)}/${adapterName}::${position}`
+  return `${toTreeItemId(configPath, dataProvider.getRootPath())}/${adapterName}::${position}`
 }
 
 function getItemTitle(item: TreeItem<StudioItemData>): string {

--- a/src/main/frontend/app/components/file-structure/tree-utilities.ts
+++ b/src/main/frontend/app/components/file-structure/tree-utilities.ts
@@ -5,6 +5,7 @@ import MailIcon from '../../../icons/solar/Mailbox.svg?react'
 import FolderIcon from '../../../icons/solar/Folder.svg?react'
 import type { FileTreeNode } from '~/types/filesystem.types'
 import type { TreeRef } from 'react-complex-tree'
+import { relativeTo } from '~/utils/path-utils'
 
 export function getListenerIcon(listenerType: string | null) {
   if (!listenerType) return CodeIcon
@@ -31,8 +32,8 @@ export function getAncestorIds(itemId: string): string[] {
 }
 
 export function toTreeItemId(absolutePath: string, rootPath: string): string {
-  const relativePath = absolutePath.slice(rootPath.length).replace(/^[/\\]/, '')
-  return `root/${relativePath.split(/[/\\]/).join('/')}`
+  const relativePath = relativeTo(rootPath, absolutePath)
+  return relativePath ? `root/${relativePath}` : 'root'
 }
 
 export function isVisibleInTree(itemId: string | null, expandedItems: string[]): boolean {

--- a/src/main/frontend/app/components/file-structure/use-studio-context-menu.ts
+++ b/src/main/frontend/app/components/file-structure/use-studio-context-menu.ts
@@ -13,6 +13,7 @@ import {
   FILE_NAME_PATTERNS,
   FOLDER_OR_ADAPTER_NAME_PATTERNS,
 } from '~/components/file-structure/name-input-dialog'
+import { getBaseName, getParentPath, joinPath, relativeTo } from '~/utils/path-utils'
 import { openInStudio } from '~/actions/navigationActions'
 
 export type StudioItemType = 'root' | 'folder' | 'configuration' | 'adapter' | 'file'
@@ -58,7 +59,7 @@ export function detectItemType(data: StudioItemData, isFolder?: boolean): Studio
 
   if (isFolder) return 'folder'
 
-  const lastSegment = path.split(/[/\\]/).at(-1) ?? path
+  const lastSegment = getBaseName(path)
   if (lastSegment.includes('.')) return 'file'
   return 'folder'
 }
@@ -68,11 +69,6 @@ export function getItemName(data: StudioItemData): string {
   if ('adapterName' in data) return (data as StudioAdapterData).adapterName
   if ('name' in data) return (data as StudioFolderData).name
   return 'Unnamed'
-}
-
-function getParentDir(filePath: string): string {
-  const lastSep = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'))
-  return lastSep > 0 ? filePath.slice(0, lastSep) : filePath
 }
 
 function ensureXmlExtension(name: string): string {
@@ -92,12 +88,12 @@ export function resolveItemPaths(
 
   if (itemType === 'adapter') {
     const configPath = (data as StudioAdapterData).configPath
-    return { path: configPath, folderPath: getParentDir(configPath) }
+    return { path: configPath, folderPath: getParentPath(configPath) }
   }
 
   const folderData = data as StudioFolderData
   if (itemType === 'configuration' || itemType === 'file') {
-    return { path: folderData.path, folderPath: getParentDir(folderData.path) }
+    return { path: folderData.path, folderPath: getParentPath(folderData.path) }
   }
 
   return { path: folderData.path, folderPath: folderData.path }
@@ -179,13 +175,13 @@ export function useStudioContextMenu({ projectName, dataProvider }: UseStudioCon
         onSubmit: async (name: string) => {
           const fileName = ensureXmlExtension(name)
           try {
-            const folderPath = menu.folderPath.replace(/[/\\]$/, '')
-            const absoluteFilePath = `${folderPath}/${fileName}`
-            const { adapterName, adapterPosition } = await createConfigurationFile(projectName, absoluteFilePath)
+            const relativeFolder = relativeTo(dataProvider.getRootPath(), menu.folderPath)
+            const relativePath = relativeFolder ? joinPath(relativeFolder, fileName) : fileName
+            const { adapterName, adapterPosition } = await createConfigurationFile(projectName, relativePath)
             await dataProvider.reloadDirectory('root')
 
             if (adapterName) {
-              openInStudio(navigate, { adapterName, filepath: absoluteFilePath, adapterPosition })
+              openInStudio(navigate, { adapterName, filepath: relativePath, adapterPosition })
             }
           } catch (error) {
             logApiError('Failed to create configuration', error as Error)
@@ -273,7 +269,7 @@ export function useStudioContextMenu({ projectName, dataProvider }: UseStudioCon
               clearConfigurationFileCache(projectName, menu.path)
               useTabStore.getState().renameTabsForConfig(menu.path, newPath)
             } else {
-              await renameFile(projectName, menu.path, `${getParentDir(menu.path)}/${newName}`)
+              await renameFile(projectName, menu.path, `${getParentPath(menu.path)}/${newName}`)
             }
             await dataProvider.reloadDirectory('root')
           } catch (error) {

--- a/src/main/frontend/app/routes/configurations/add-configuration-modal.tsx
+++ b/src/main/frontend/app/routes/configurations/add-configuration-modal.tsx
@@ -47,14 +47,25 @@ export default function AddConfigurationModal({
         setLoading(false)
         return
       }
-      // Ensure .xml suffix
+
+      if (/[/\\]/.test(configname) || configname.includes('..')) {
+        setError(String.raw`Filename cannot contain "/", "\" or ".."`)
+        setLoading(false)
+        return
+      }
+
       if (!configname.toLowerCase().endsWith('.xml')) {
         configname = `${configname}.xml`
       }
 
-      const folderPath = rootLocationName.replace(/[/\\]$/, '')
-      const absoluteFilePath = `${folderPath}/${configname}`
-      await createConfigurationFile(currentConfiguration.name, absoluteFilePath)
+      const projectRoot = currentConfiguration.rootPath.replace(/[/\\]$/, '')
+      const selectedFolder = rootLocationName.replace(/[/\\]$/, '')
+      const relativePath =
+              !selectedFolder || selectedFolder === projectRoot
+                      ? configname
+                      : `${selectedFolder.slice(projectRoot.length + 1).replaceAll('\\', '/')}/${configname}`
+
+      await createConfigurationFile(currentConfiguration.name, relativePath)
       const updatedProject = await fetchProject(currentConfiguration.name)
       setProject(updatedProject)
       onSuccess?.()
@@ -85,10 +96,13 @@ export default function AddConfigurationModal({
     setIsOpenPickerOpen(false)
   }
 
+  const trimmedFilename = filename.trim()
+  const filenameHasInvalidChars = /[/\\]/.test(trimmedFilename) || trimmedFilename.includes('..')
+  const isFilenameValid = trimmedFilename.length > 0 && !filenameHasInvalidChars
+
   const displayFilename = (() => {
-    const trimmed = filename.trim()
-    if (!trimmed) return ''
-    return trimmed.toLowerCase().endsWith('.xml') ? trimmed : `${trimmed}.xml`
+    if (!trimmedFilename) return ''
+    return trimmedFilename.toLowerCase().endsWith('.xml') ? trimmedFilename : `${trimmedFilename}.xml`
   })()
 
   return (
@@ -122,19 +136,25 @@ export default function AddConfigurationModal({
           <label className="text-sm font-medium" htmlFor="configuration-filename-input">
             Filename
           </label>
-          <div className="ml-2 flex w-full items-center">
-            <Input
-              id="configuration-filename-input"
-              value={filename}
-              onChange={(event) => setFilename(event.target.value)}
-              placeholder="Choose a filename"
-              aria-label="configuration filename"
-            />
+          <div className="ml-2 flex w-full flex-col">
+            <div className="flex w-full items-center gap-1">
+              <Input
+                id="configuration-filename-input"
+                value={filename}
+                onChange={(event) => setFilename(event.target.value)}
+                placeholder="Choose a filename"
+                aria-label="configuration filename"
+              />
+              <span className="text-foreground-muted text-sm">.xml</span>
+            </div>
+            {filenameHasInvalidChars && (
+              <p className="mt-1 text-xs text-red-500">{String.raw`Filename cannot contain "/", "\" or ".."`}</p>
+            )}
           </div>
         </div>
 
         <div className="flex gap-2">
-          <Button onClick={handleAdd} disabled={loading} className="disabled:opacity-50">
+          <Button onClick={handleAdd} disabled={loading || !isFilenameValid} className="disabled:opacity-50">
             {loading ? 'Adding...' : `Add ${displayFilename || 'configuration file'} to ${currentConfiguration.name}`}
           </Button>
 

--- a/src/main/frontend/app/routes/configurations/add-configuration-modal.tsx
+++ b/src/main/frontend/app/routes/configurations/add-configuration-modal.tsx
@@ -7,6 +7,7 @@ import CloseButton from '~/components/inputs/close-button'
 import Input from '~/components/inputs/input'
 import DirectoryPicker from '~/components/directory-picker/directory-picker'
 import { fetchProject } from '~/services/project-service'
+import { containsPathSeparator, joinPath, relativeTo } from '~/utils/path-utils'
 
 type AddConfigurationModalProperties = {
   isOpen: boolean
@@ -48,7 +49,7 @@ export default function AddConfigurationModal({
         return
       }
 
-      if (/[/\\]/.test(configname) || configname.includes('..')) {
+      if (containsPathSeparator(configname) || configname.includes('..')) {
         setError(String.raw`Filename cannot contain "/", "\" or ".."`)
         setLoading(false)
         return
@@ -58,12 +59,8 @@ export default function AddConfigurationModal({
         configname = `${configname}.xml`
       }
 
-      const projectRoot = currentConfiguration.rootPath.replace(/[/\\]$/, '')
-      const selectedFolder = rootLocationName.replace(/[/\\]$/, '')
-      const relativePath =
-              !selectedFolder || selectedFolder === projectRoot
-                      ? configname
-                      : `${selectedFolder.slice(projectRoot.length + 1).replaceAll('\\', '/')}/${configname}`
+      const relativeFolder = relativeTo(currentConfiguration.rootPath, rootLocationName)
+      const relativePath = relativeFolder ? joinPath(relativeFolder, configname) : configname
 
       await createConfigurationFile(currentConfiguration.name, relativePath)
       const updatedProject = await fetchProject(currentConfiguration.name)
@@ -97,7 +94,7 @@ export default function AddConfigurationModal({
   }
 
   const trimmedFilename = filename.trim()
-  const filenameHasInvalidChars = /[/\\]/.test(trimmedFilename) || trimmedFilename.includes('..')
+  const filenameHasInvalidChars = containsPathSeparator(trimmedFilename) || trimmedFilename.includes('..')
   const isFilenameValid = trimmedFilename.length > 0 && !filenameHasInvalidChars
 
   const displayFilename = (() => {

--- a/src/main/frontend/app/routes/configurations/configuration-file-tile.tsx
+++ b/src/main/frontend/app/routes/configurations/configuration-file-tile.tsx
@@ -7,6 +7,7 @@ import IconButton from '~/components/inputs/icon-button'
 import IconLabelButton from '~/components/inputs/icon-label-button'
 import ConfirmDeleteDialog from '~/components/file-structure/confirm-delete-dialog'
 import { useState } from 'react'
+import { getBaseName } from '~/utils/path-utils'
 
 type ConfigurationFileTileProperties = {
   filepath: string
@@ -29,7 +30,7 @@ export default function ConfigurationFileTile({
   }
 
   const handleOpenInEditor = () => {
-    const fileName = relativePath.split(/[/\\]/).pop()
+    const fileName = getBaseName(relativePath)
     if (!fileName) return
     openInEditor(fileName, filepath, navigate)
   }
@@ -82,7 +83,7 @@ export default function ConfigurationFileTile({
 
       {showDeleteDialog && (
         <ConfirmDeleteDialog
-          name={relativePath.split(/[/\\]/).pop() ?? relativePath}
+          name={getBaseName(relativePath)}
           isFolder={false}
           onCancel={() => setShowDeleteDialog(false)}
           onConfirm={handleConfirmDelete}

--- a/src/main/frontend/app/routes/configurations/configuration-overview.tsx
+++ b/src/main/frontend/app/routes/configurations/configuration-overview.tsx
@@ -11,31 +11,12 @@ import type { FileTreeNode } from '~/types/filesystem.types'
 import { fetchProjectTree } from '~/services/file-tree-service'
 import Button from '~/components/inputs/button'
 import Search from '~/components/search/search'
-import { normalizePath, toRelativePath } from '~/utils/path-utils'
+import { toRelativePath } from '~/utils/path-utils'
 
 type ConfigurationFile = {
   path: string
   relativePath: string
   adapterNames: string[]
-}
-
-function findConfigurationsDir(node: FileTreeNode | undefined | null): FileTreeNode | null {
-  if (!node || !node.path) return null
-
-  const normalizedPath = normalizePath(node.path)
-
-  if (node.type === 'DIRECTORY' && normalizedPath.endsWith(`/src/main/configurations/${node.name}`)) {
-    return node
-  }
-
-  if (!node.children) return null
-
-  for (const child of node.children) {
-    const found = findConfigurationsDir(child)
-    if (found) return found
-  }
-
-  return null
 }
 
 function collectXmlFiles(node: FileTreeNode | undefined | null): FileTreeNode[] {
@@ -61,7 +42,6 @@ export default function ConfigurationOverview() {
   const [showModal, setShowModal] = useState(false)
   const [tree, setTree] = useState<FileTreeNode | null>(null)
   const [isLoading, setIsLoading] = useState(false)
-  const [configurationsDir, setConfigurationsDir] = useState<FileTreeNode | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
   const [debouncedQuery, setDebouncedQuery] = useState(searchQuery)
 
@@ -91,13 +71,6 @@ export default function ConfigurationOverview() {
     return () => controller.abort()
   }, [loadTree])
 
-  useEffect(() => {
-    if (tree) {
-      const configDir = findConfigurationsDir(tree)
-      setConfigurationsDir(configDir)
-    }
-  }, [tree])
-
   const handleConfigAdded = useCallback(() => {
     setShowModal(false)
     loadTree()
@@ -112,12 +85,15 @@ export default function ConfigurationOverview() {
   const configFiles = useMemo(() => {
     if (!tree || !currentConfigurationProject) return []
 
-    const configurationDirectory = findConfigurationsDir(tree)
-    if (!configurationDirectory) return []
-
-    const xmlFiles = collectXmlFiles(configurationDirectory)
+    /*
+     * The project root already is the configuration directory (it is the opened
+     * src/main/configurations/<configuration> folder, or a freshly created project
+     * whose Configuration.xml lives at the top level), so collect the configuration
+     * files straight from the root rather than searching for a nested directory.
+     */
+    const xmlFiles = collectXmlFiles(tree)
     return xmlFiles.map((file) => {
-      const relativePath = toRelativePath(file.path, `${configurationDirectory.path}/`) ?? file.name
+      const relativePath = toRelativePath(file.path, `${tree.path}/`) ?? file.name
       return { ...file, relativePath, path: file.path }
     })
   }, [tree, currentConfigurationProject])
@@ -208,7 +184,7 @@ export default function ConfigurationOverview() {
         onClose={() => setShowModal(false)}
         onSuccess={handleConfigAdded}
         currentConfiguration={currentConfigurationProject}
-        configurationsDirPath={configurationsDir?.path ?? ''}
+        configurationsDirPath={tree?.path ?? ''}
       />
     </div>
   )

--- a/src/main/frontend/app/routes/configurations/configuration-overview.tsx
+++ b/src/main/frontend/app/routes/configurations/configuration-overview.tsx
@@ -11,7 +11,7 @@ import type { FileTreeNode } from '~/types/filesystem.types'
 import { fetchProjectTree } from '~/services/file-tree-service'
 import Button from '~/components/inputs/button'
 import Search from '~/components/search/search'
-import { toRelativePath } from '~/utils/path-utils'
+import { relativeTo } from '~/utils/path-utils'
 
 type ConfigurationFile = {
   path: string
@@ -85,15 +85,9 @@ export default function ConfigurationOverview() {
   const configFiles = useMemo(() => {
     if (!tree || !currentConfigurationProject) return []
 
-    /*
-     * The project root already is the configuration directory (it is the opened
-     * src/main/configurations/<configuration> folder, or a freshly created project
-     * whose Configuration.xml lives at the top level), so collect the configuration
-     * files straight from the root rather than searching for a nested directory.
-     */
     const xmlFiles = collectXmlFiles(tree)
     return xmlFiles.map((file) => {
-      const relativePath = toRelativePath(file.path, `${tree.path}/`) ?? file.name
+      const relativePath = relativeTo(tree.path, file.path) || file.name
       return { ...file, relativePath, path: file.path }
     })
   }, [tree, currentConfigurationProject])

--- a/src/main/frontend/app/routes/projectlanding/clone-configuration-modal.tsx
+++ b/src/main/frontend/app/routes/projectlanding/clone-configuration-modal.tsx
@@ -4,6 +4,7 @@ import Button from '~/components/inputs/button'
 import CloseButton from '~/components/inputs/close-button'
 import Input from '~/components/inputs/input'
 import { filesystemService } from '~/services/filesystem-service'
+import { joinPath } from '~/utils/path-utils'
 
 type CloneProjectModalProperties = {
   isLocal: boolean
@@ -39,6 +40,9 @@ export default function CloneConfigurationModal({
     .pop()
     ?.replace(/\.git$/i, '')
 
+  const targetName = repoName || 'cloned-project'
+  const targetPath = location ? joinPath(location, targetName) : targetName
+
   const handleClone = () => {
     if (!repoUrl.trim()) return
     if (isLocal && !location) return
@@ -53,7 +57,7 @@ export default function CloneConfigurationModal({
       finalPath = location ? `${location}/${name}` : name
     }
 
-    onClone(repoUrl.trim(), finalPath, token)
+    onClone(repoUrl.trim(), finalPath, token || undefined)
     handleClose()
   }
 
@@ -113,14 +117,7 @@ export default function CloneConfigurationModal({
             </div>
           )}
 
-          {repoName && (
-            <p className="text-foreground-muted mb-4 text-xs">
-              Will clone to:{' '}
-              {isLocal
-                ? `${location}${location.includes('/') ? '/' : '\\'}${repoName}`
-                : `${location ? `${location}/` : ''}${repoName}`}
-            </p>
-          )}
+          {repoName && <p className="text-foreground-muted mb-4 text-xs">Will clone to: {targetPath}</p>}
 
           <div className="flex gap-2">
             <Button

--- a/src/main/frontend/app/routes/projectlanding/clone-configuration-modal.tsx
+++ b/src/main/frontend/app/routes/projectlanding/clone-configuration-modal.tsx
@@ -57,7 +57,7 @@ export default function CloneConfigurationModal({
       finalPath = location ? `${location}/${name}` : name
     }
 
-    onClone(repoUrl.trim(), finalPath, token || undefined)
+    onClone(repoUrl.trim(), finalPath, token)
     handleClose()
   }
 

--- a/src/main/frontend/app/routes/projectlanding/new-configuration-modal.tsx
+++ b/src/main/frontend/app/routes/projectlanding/new-configuration-modal.tsx
@@ -3,7 +3,10 @@ import DirectoryPicker from '~/components/directory-picker/directory-picker'
 import Button from '~/components/inputs/button'
 import CloseButton from '~/components/inputs/close-button'
 import Input from '~/components/inputs/input'
+import ValidatedInput from '~/components/inputs/validatedInput'
+import { PROJECT_NAME_PATTERNS } from '~/components/file-structure/name-input-dialog'
 import { filesystemService } from '~/services/filesystem-service'
+import { joinPath, normalizePath, stripTrailingSeparators } from '~/utils/path-utils'
 
 type NewProjectModalProperties = {
   isLocal: boolean
@@ -12,8 +15,6 @@ type NewProjectModalProperties = {
   initialPath: string
 }
 
-const CONFIG_DIR = 'src/main/configurations'
-
 export default function NewConfigurationModal({
   isLocal,
   onClose,
@@ -21,6 +22,7 @@ export default function NewConfigurationModal({
   initialPath,
 }: Readonly<NewProjectModalProperties>) {
   const [name, setName] = useState('')
+  const [isNameValid, setIsNameValid] = useState(false)
   const [location, setLocation] = useState('')
   const [showPicker, setShowPicker] = useState(false)
 
@@ -32,14 +34,14 @@ export default function NewConfigurationModal({
 
     filesystemService
       .resolveNearestAccessiblePath(initialPath)
-      .then(setLocation)
+      .then((resolved) => setLocation(normalizePath(resolved)))
       .catch(() => setLocation(''))
   }, [isLocal, initialPath])
 
   const handleCreate = () => {
-    if (!name.trim() || (isLocal && !location)) return
+    if (!isNameValid || !name.trim() || (isLocal && !location)) return
     const trimmedName = name.trim()
-    onCreate(trimmedName, location ?? '')
+    onCreate(trimmedName, stripTrailingSeparators(location ?? ''))
     handleClose()
   }
 
@@ -77,8 +79,10 @@ export default function NewConfigurationModal({
 
           <div className="mb-4">
             <label className="mb-1 block text-sm font-medium">Configuration Name</label>
-            <Input
+            <ValidatedInput
               value={name}
+              patterns={PROJECT_NAME_PATTERNS}
+              onValidChange={setIsNameValid}
               onChange={(event) => setName(event.target.value)}
               placeholder="Enter configuration name"
             />
@@ -94,7 +98,7 @@ export default function NewConfigurationModal({
           <div className="flex gap-2">
             <Button
               onClick={handleCreate}
-              disabled={!name.trim() || (isLocal && !location)}
+              disabled={!isNameValid || !name.trim() || (isLocal && !location)}
               className="disabled:text-foreground-muted disabled:cursor-not-allowed disabled:opacity-50"
             >
               Create Configuration
@@ -108,7 +112,7 @@ export default function NewConfigurationModal({
       {showPicker && (
         <DirectoryPicker
           onSelect={(path) => {
-            setLocation(path)
+            setLocation(normalizePath(path))
             setShowPicker(false)
           }}
           onCancel={() => setShowPicker(false)}
@@ -120,9 +124,6 @@ export default function NewConfigurationModal({
 }
 
 function getConfigurationPath(location: string, name: string, isLocal: boolean) {
-  let configPath = isLocal ? location.replace('\\', '/') : location
-  if (!configPath.endsWith(CONFIG_DIR)) {
-    configPath = `${configPath}/${CONFIG_DIR}`
-  }
-  return `${configPath}/${name.trim()}`
+  const base = isLocal ? normalizePath(location) : location
+  return joinPath(base, name.trim())
 }

--- a/src/main/frontend/app/routes/studio/studio.tsx
+++ b/src/main/frontend/app/routes/studio/studio.tsx
@@ -14,6 +14,7 @@ import SidebarLayout from '~/components/sidebars-layout/sidebar-layout'
 import useTabStore from '~/stores/tab-store'
 import { useShallow } from 'zustand/react/shallow'
 import { openInEditor } from '~/actions/navigationActions'
+import { getBaseName } from '~/utils/path-utils'
 import Button from '~/components/inputs/button'
 import useFlowStore, { isStickyNote } from '~/stores/flow-store'
 import type { StickyNote } from '~/routes/studio/canvas/nodetypes/sticky-note'
@@ -201,7 +202,7 @@ export default function Studio() {
   const handleOpenInEditor = useCallback(() => {
     if (!activeTabPath) return
 
-    const fileName = activeTabPath.split(/[/\\]/).pop()
+    const fileName = getBaseName(activeTabPath)
     if (!fileName) return
 
     openInEditor(fileName, activeTabPath, navigate)

--- a/src/main/frontend/app/utils/path-utils.spec.ts
+++ b/src/main/frontend/app/utils/path-utils.spec.ts
@@ -1,0 +1,97 @@
+import { getParentPath, joinPath, normalizePath, stripTrailingSeparators, toRelativePath } from './path-utils'
+
+const USERS_FOO = 'C:/Users/foo'
+const PROJECT_MARKER = 'C:/proj/'
+
+describe('normalizePath', () => {
+  it('converts backslashes to forward slashes', () => {
+    expect(normalizePath(String.raw`C:\Users\foo`)).toBe(USERS_FOO)
+  })
+
+  it('leaves forward-slash paths untouched', () => {
+    expect(normalizePath(USERS_FOO)).toBe(USERS_FOO)
+  })
+
+  it('shows a drive root with a forward slash', () => {
+    expect(normalizePath('C:\\')).toBe('C:/')
+  })
+})
+
+describe('stripTrailingSeparators', () => {
+  it('removes trailing separators from a regular path', () => {
+    expect(stripTrailingSeparators(`${USERS_FOO}/`)).toBe(USERS_FOO)
+    expect(stripTrailingSeparators(`${USERS_FOO}///`)).toBe(USERS_FOO)
+    expect(stripTrailingSeparators('/home/foo/')).toBe('/home/foo')
+  })
+
+  it('keeps a Windows drive root as "C:/"', () => {
+    expect(stripTrailingSeparators('C:/')).toBe('C:/')
+    expect(stripTrailingSeparators('C:\\')).toBe('C:/')
+    expect(stripTrailingSeparators('C:')).toBe('C:/')
+  })
+
+  it('keeps the Unix root as "/"', () => {
+    expect(stripTrailingSeparators('/')).toBe('/')
+    expect(stripTrailingSeparators('///')).toBe('/')
+  })
+
+  it('returns empty input unchanged', () => {
+    expect(stripTrailingSeparators('')).toBe('')
+  })
+})
+
+describe('joinPath', () => {
+  it('joins a base and a segment with a single forward slash', () => {
+    expect(joinPath('C:/Users', 'foo')).toBe(USERS_FOO)
+  })
+
+  it('tolerates a trailing separator on the base', () => {
+    expect(joinPath('C:/Users/', 'foo')).toBe(USERS_FOO)
+    expect(joinPath('/home//', 'foo')).toBe('/home/foo')
+  })
+
+  it('tolerates a leading separator on the segment', () => {
+    expect(joinPath('C:/Users', '/foo')).toBe(USERS_FOO)
+  })
+
+  it('collapses a drive root into an absolute path (never drive-relative)', () => {
+    expect(joinPath('C:\\', 'foo')).toBe('C:/foo')
+    expect(joinPath('C:/', 'foo')).toBe('C:/foo')
+  })
+
+  it('treats an empty base as the Unix root', () => {
+    expect(joinPath('', 'foo')).toBe('/foo')
+  })
+})
+
+describe('getParentPath', () => {
+  it('returns the parent directory', () => {
+    expect(getParentPath('C:/Users/MyProject')).toBe('C:/Users')
+  })
+
+  it('keeps the drive root separator when the parent is the drive', () => {
+    expect(getParentPath('C:/MyProject')).toBe('C:/')
+  })
+
+  it('returns empty input unchanged', () => {
+    expect(getParentPath('')).toBe('')
+  })
+})
+
+describe('toRelativePath', () => {
+  it('returns the portion of the path after the marker', () => {
+    expect(toRelativePath(`${PROJECT_MARKER}Configuration.xml`, PROJECT_MARKER)).toBe('Configuration.xml')
+  })
+
+  it('preserves nested subfolders', () => {
+    expect(toRelativePath(`${PROJECT_MARKER}sub/Config.xml`, PROJECT_MARKER)).toBe('sub/Config.xml')
+  })
+
+  it('matches even when path and marker use different separators', () => {
+    expect(toRelativePath(String.raw`C:\proj\sub\Config.xml`, PROJECT_MARKER)).toBe('sub/Config.xml')
+  })
+
+  it('returns null when the marker is not present', () => {
+    expect(toRelativePath('C:/other/file.xml', PROJECT_MARKER)).toBeNull()
+  })
+})

--- a/src/main/frontend/app/utils/path-utils.spec.ts
+++ b/src/main/frontend/app/utils/path-utils.spec.ts
@@ -1,7 +1,17 @@
-import { getParentPath, joinPath, normalizePath, stripTrailingSeparators, toRelativePath } from './path-utils'
+import {
+  containsPathSeparator,
+  getBaseName,
+  getParentPath,
+  joinPath,
+  normalizePath,
+  relativeTo,
+  stripTrailingSeparators,
+} from './path-utils'
 
 const USERS_FOO = 'C:/Users/foo'
-const PROJECT_MARKER = 'C:/proj/'
+const PROJECT_ROOT = 'C:/proj'
+const CONFIG_FILE = 'Config.xml'
+const SUB_CONFIG = `sub/${CONFIG_FILE}`
 
 describe('normalizePath', () => {
   it('converts backslashes to forward slashes', () => {
@@ -17,11 +27,26 @@ describe('normalizePath', () => {
   })
 })
 
+describe('containsPathSeparator', () => {
+  it('detects forward and back slashes', () => {
+    expect(containsPathSeparator('a/b')).toBe(true)
+    expect(containsPathSeparator(String.raw`a\b`)).toBe(true)
+  })
+
+  it('is false for a plain segment', () => {
+    expect(containsPathSeparator(CONFIG_FILE)).toBe(false)
+  })
+})
+
 describe('stripTrailingSeparators', () => {
   it('removes trailing separators from a regular path', () => {
     expect(stripTrailingSeparators(`${USERS_FOO}/`)).toBe(USERS_FOO)
     expect(stripTrailingSeparators(`${USERS_FOO}///`)).toBe(USERS_FOO)
     expect(stripTrailingSeparators('/home/foo/')).toBe('/home/foo')
+  })
+
+  it('normalizes backslashes while stripping', () => {
+    expect(stripTrailingSeparators('C:\\Users\\foo\\')).toBe(USERS_FOO)
   })
 
   it('keeps a Windows drive root as "C:/"', () => {
@@ -40,6 +65,25 @@ describe('stripTrailingSeparators', () => {
   })
 })
 
+describe('getBaseName', () => {
+  it('returns the last segment', () => {
+    expect(getBaseName(`${PROJECT_ROOT}/${SUB_CONFIG}`)).toBe(CONFIG_FILE)
+    expect(getBaseName(String.raw`C:\proj\sub\Config.xml`)).toBe(CONFIG_FILE)
+  })
+
+  it('ignores trailing separators', () => {
+    expect(getBaseName(`${PROJECT_ROOT}/sub/`)).toBe('sub')
+  })
+
+  it('returns the input when there is no separator', () => {
+    expect(getBaseName(CONFIG_FILE)).toBe(CONFIG_FILE)
+  })
+
+  it('returns an empty string for an empty path', () => {
+    expect(getBaseName('')).toBe('')
+  })
+})
+
 describe('joinPath', () => {
   it('joins a base and a segment with a single forward slash', () => {
     expect(joinPath('C:/Users', 'foo')).toBe(USERS_FOO)
@@ -52,6 +96,10 @@ describe('joinPath', () => {
 
   it('tolerates a leading separator on the segment', () => {
     expect(joinPath('C:/Users', '/foo')).toBe(USERS_FOO)
+  })
+
+  it('normalizes backslashes in either argument', () => {
+    expect(joinPath(String.raw`C:\Users`, 'foo')).toBe(USERS_FOO)
   })
 
   it('collapses a drive root into an absolute path (never drive-relative)', () => {
@@ -69,6 +117,10 @@ describe('getParentPath', () => {
     expect(getParentPath('C:/Users/MyProject')).toBe('C:/Users')
   })
 
+  it('normalizes backslashes', () => {
+    expect(getParentPath(String.raw`C:\Users\MyProject`)).toBe('C:/Users')
+  })
+
   it('keeps the drive root separator when the parent is the drive', () => {
     expect(getParentPath('C:/MyProject')).toBe('C:/')
   })
@@ -78,20 +130,28 @@ describe('getParentPath', () => {
   })
 })
 
-describe('toRelativePath', () => {
-  it('returns the portion of the path after the marker', () => {
-    expect(toRelativePath(`${PROJECT_MARKER}Configuration.xml`, PROJECT_MARKER)).toBe('Configuration.xml')
+describe('relativeTo', () => {
+  it('returns the portion of the path below the base', () => {
+    expect(relativeTo(PROJECT_ROOT, `${PROJECT_ROOT}/Configuration.xml`)).toBe('Configuration.xml')
   })
 
   it('preserves nested subfolders', () => {
-    expect(toRelativePath(`${PROJECT_MARKER}sub/Config.xml`, PROJECT_MARKER)).toBe('sub/Config.xml')
+    expect(relativeTo(PROJECT_ROOT, `${PROJECT_ROOT}/${SUB_CONFIG}`)).toBe(SUB_CONFIG)
   })
 
-  it('matches even when path and marker use different separators', () => {
-    expect(toRelativePath(String.raw`C:\proj\sub\Config.xml`, PROJECT_MARKER)).toBe('sub/Config.xml')
+  it('tolerates a trailing separator on the base', () => {
+    expect(relativeTo(`${PROJECT_ROOT}/`, `${PROJECT_ROOT}/${SUB_CONFIG}`)).toBe(SUB_CONFIG)
   })
 
-  it('returns null when the marker is not present', () => {
-    expect(toRelativePath('C:/other/file.xml', PROJECT_MARKER)).toBeNull()
+  it('matches even when base and target use different separators', () => {
+    expect(relativeTo(PROJECT_ROOT, String.raw`C:\proj\sub\Config.xml`)).toBe(SUB_CONFIG)
+  })
+
+  it('returns an empty string when target equals base', () => {
+    expect(relativeTo(PROJECT_ROOT, `${PROJECT_ROOT}/`)).toBe('')
+  })
+
+  it('returns null when target is not inside base', () => {
+    expect(relativeTo(PROJECT_ROOT, 'C:/other/file.xml')).toBeNull()
   })
 })

--- a/src/main/frontend/app/utils/path-utils.ts
+++ b/src/main/frontend/app/utils/path-utils.ts
@@ -1,39 +1,44 @@
-/**
- * Extracts the portion of a path after the first occurrence of a marker segment.
- * Returns null if the marker is not found.
- */
-export function toRelativePath(absolutePath: string, marker: string): string | null {
-  const normalizedPath = normalizePath(absolutePath)
-  const normalizedMarker = normalizePath(marker)
-  const idx = normalizedPath.indexOf(normalizedMarker)
-  return idx === -1 ? null : normalizedPath.slice(idx + normalizedMarker.length)
-}
-
-export function normalizePath(path: string) {
+export function normalizePath(path: string): string {
   return path.replaceAll('\\', '/')
 }
 
-export function getParentPath(path: string): string {
-  if (!path) return path // Return empty string if path is empty, small optimization to avoid regex processing
-  const parent = path.replace(/\/?[^/]*$/, '')
-
-  if (/^[a-zA-Z]:$/.test(parent)) return `${parent}/`
-  return parent
+export function containsPathSeparator(path: string): boolean {
+  return /[/\\]/.test(path)
 }
 
 /**
- * Removes trailing path separators (`/` or `\`) from a path.
+ * Removes trailing path separators from a path, keeping filesystem roots intact
  */
 export function stripTrailingSeparators(path: string): string {
   if (!path) return path
-  const stripped = path.replace(/[\\/]+$/, '')
+  const stripped = normalizePath(path).replace(/\/+$/, '')
   if (stripped === '') return '/'
   if (/^[a-zA-Z]:$/.test(stripped)) return `${stripped}/`
   return stripped
 }
 
+export function getBaseName(path: string): string {
+  const normalized = stripTrailingSeparators(path)
+  return normalized.slice(normalized.lastIndexOf('/') + 1)
+}
+
+export function getParentPath(path: string): string {
+  if (!path) return path
+  const parent = normalizePath(path).replace(/\/?[^/]*$/, '')
+  if (/^[a-zA-Z]:$/.test(parent)) return `${parent}/`
+  return parent
+}
+
 export function joinPath(base: string, segment: string): string {
-  const trimmedBase = base.replace(/[\\/]+$/, '')
-  const trimmedSegment = segment.replace(/^[\\/]+/, '')
+  const trimmedBase = normalizePath(base).replace(/\/+$/, '')
+  const trimmedSegment = normalizePath(segment).replace(/^\/+/, '')
   return trimmedBase ? `${trimmedBase}/${trimmedSegment}` : `/${trimmedSegment}`
+}
+
+export function relativeTo(base: string, target: string): string | null {
+  const normalizedBase = stripTrailingSeparators(base)
+  const normalizedTarget = stripTrailingSeparators(target)
+  if (normalizedTarget === normalizedBase) return ''
+  const prefix = normalizedBase.endsWith('/') ? normalizedBase : `${normalizedBase}/`
+  return normalizedTarget.startsWith(prefix) ? normalizedTarget.slice(prefix.length) : null
 }

--- a/src/main/frontend/app/utils/path-utils.ts
+++ b/src/main/frontend/app/utils/path-utils.ts
@@ -15,5 +15,25 @@ export function normalizePath(path: string) {
 
 export function getParentPath(path: string): string {
   if (!path) return path // Return empty string if path is empty, small optimization to avoid regex processing
-  return path.replace(/\/?[^/]*$/, '')
+  const parent = path.replace(/\/?[^/]*$/, '')
+
+  if (/^[a-zA-Z]:$/.test(parent)) return `${parent}/`
+  return parent
+}
+
+/**
+ * Removes trailing path separators (`/` or `\`) from a path.
+ */
+export function stripTrailingSeparators(path: string): string {
+  if (!path) return path
+  const stripped = path.replace(/[\\/]+$/, '')
+  if (stripped === '') return '/'
+  if (/^[a-zA-Z]:$/.test(stripped)) return `${stripped}/`
+  return stripped
+}
+
+export function joinPath(base: string, segment: string): string {
+  const trimmedBase = base.replace(/[\\/]+$/, '')
+  const trimmedSegment = segment.replace(/^[\\/]+/, '')
+  return trimmedBase ? `${trimmedBase}/${trimmedSegment}` : `/${trimmedSegment}`
 }

--- a/src/main/java/org/frankframework/flow/configuration/ConfigurationController.java
+++ b/src/main/java/org/frankframework/flow/configuration/ConfigurationController.java
@@ -49,11 +49,11 @@ public class ConfigurationController {
 	}
 
 	@PostMapping()
-	public ResponseEntity<AdapterLocationDTO> addConfiguration(
+	public ResponseEntity<AdapterLocationDTO> addConfigurationFile(
 			@PathVariable String projectName,
 			@RequestParam String path
 	) throws ApiException, IOException, TransformerException, ParserConfigurationException, SAXException {
-		AdapterLocationDTO adapterLocation = configurationService.addConfiguration(projectName, path);
+		AdapterLocationDTO adapterLocation = configurationService.addConfigurationFile(projectName, path);
 		return ResponseEntity.ok(adapterLocation);
 	}
 }

--- a/src/main/java/org/frankframework/flow/configuration/ConfigurationService.java
+++ b/src/main/java/org/frankframework/flow/configuration/ConfigurationService.java
@@ -101,7 +101,7 @@ public class ConfigurationService {
 	 * @return the location of the first adapter in the created file, so the frontend can open it in the studio;
 	 *         the actual content is loaded lazily when the studio renders the adapter
 	 */
-	public AdapterLocationDTO addConfiguration(String projectName, String filepath) throws IOException, ApiException, TransformerException, ParserConfigurationException, SAXException {
+	public AdapterLocationDTO addConfigurationFile(String projectName, String filepath) throws IOException, ApiException, TransformerException, ParserConfigurationException, SAXException {
 		if (filepath == null || filepath.isBlank()) {
 			throw new ApiException("Configuration path must not be empty", HttpStatus.BAD_REQUEST);
 		}

--- a/src/test/java/org/frankframework/flow/configuration/ConfigurationControllerTest.java
+++ b/src/test/java/org/frankframework/flow/configuration/ConfigurationControllerTest.java
@@ -138,7 +138,7 @@ class ConfigurationControllerTest {
 
 		String filepath = "/path/to/" + TEST_PROJECT_NAME + "/NewConfig.xml";
 
-		when(configurationService.addConfiguration(TEST_PROJECT_NAME, filepath))
+		when(configurationService.addConfigurationFile(TEST_PROJECT_NAME, filepath))
 				.thenReturn(new AdapterLocationDTO("SampleAdapter", 0));
 		when(configurationProjectService.toDto(configurationProject))
 				.thenReturn(new ConfigurationProjectDTO(
@@ -156,6 +156,6 @@ class ConfigurationControllerTest {
 				.andExpect(jsonPath("$.adapterName").value("SampleAdapter"))
 				.andExpect(jsonPath("$.adapterPosition").value(0));
 
-		verify(configurationService).addConfiguration(TEST_PROJECT_NAME, filepath);
+		verify(configurationService).addConfigurationFile(TEST_PROJECT_NAME, filepath);
 	}
 }

--- a/src/test/java/org/frankframework/flow/configuration/ConfigurationServiceTest.java
+++ b/src/test/java/org/frankframework/flow/configuration/ConfigurationServiceTest.java
@@ -346,9 +346,7 @@ class ConfigurationServiceTest {
 		AdapterLocationDTO result = configurationService.addConfiguration("myproject", target.toString());
 
 		assertNotNull(result);
-
-		Path expectedFile = projectDir.resolve("NewConfig.xml");
-		assertTrue(Files.exists(expectedFile), "NewConfig.xml should be created on disk");
+		assertTrue(Files.exists(target), "NewConfig.xml should be created inside src/main/configurations");
 		verify(fileTreeService).invalidateTreeCache("myproject");
 	}
 

--- a/src/test/java/org/frankframework/flow/configuration/ConfigurationServiceTest.java
+++ b/src/test/java/org/frankframework/flow/configuration/ConfigurationServiceTest.java
@@ -346,9 +346,9 @@ class ConfigurationServiceTest {
 		AdapterLocationDTO result = configurationService.addConfiguration("myproject", target.toString());
 
 		assertNotNull(result);
-		assertEquals("SampleAdapter", result.adapterName(), "Should point at the template adapter");
-		assertEquals(0, result.adapterPosition());
-		assertTrue(Files.exists(target), "NewConfig.xml should be created on disk");
+
+		Path expectedFile = projectDir.resolve("NewConfig.xml");
+		assertTrue(Files.exists(expectedFile), "NewConfig.xml should be created on disk");
 		verify(fileTreeService).invalidateTreeCache("myproject");
 	}
 
@@ -365,7 +365,8 @@ class ConfigurationServiceTest {
 		Path target = projectDir.resolve("subfolder/NestedConfig.xml");
 		configurationService.addConfiguration("myproject", target.toString());
 
-		assertTrue(Files.exists(target));
+		Path expectedFile = projectDir.resolve("subfolder/NestedConfig.xml");
+		assertTrue(Files.exists(expectedFile));
 	}
 
 	@Test

--- a/src/test/java/org/frankframework/flow/configuration/ConfigurationServiceTest.java
+++ b/src/test/java/org/frankframework/flow/configuration/ConfigurationServiceTest.java
@@ -343,7 +343,7 @@ class ConfigurationServiceTest {
 		when(configurationProjectService.getProject("myproject")).thenReturn(configurationProject);
 
 		Path target = projectDir.resolve("src/main/configurations/NewConfig.xml");
-		AdapterLocationDTO result = configurationService.addConfiguration("myproject", target.toString());
+		AdapterLocationDTO result = configurationService.addConfigurationFile("myproject", target.toString());
 
 		assertNotNull(result);
 		assertTrue(Files.exists(target), "NewConfig.xml should be created inside src/main/configurations");
@@ -361,7 +361,7 @@ class ConfigurationServiceTest {
 		when(configurationProjectService.getProject("myproject")).thenReturn(configurationProject);
 
 		Path target = projectDir.resolve("subfolder/NestedConfig.xml");
-		configurationService.addConfiguration("myproject", target.toString());
+		configurationService.addConfigurationFile("myproject", target.toString());
 
 		Path expectedFile = projectDir.resolve("subfolder/NestedConfig.xml");
 		assertTrue(Files.exists(expectedFile));
@@ -370,13 +370,13 @@ class ConfigurationServiceTest {
 	@Test
 	void addConfiguration_ProjectNotFound_ThrowsException() throws ApiException {
 		when(configurationProjectService.getProject("unknown")).thenThrow(new ApiException("not found", HttpStatus.NOT_FOUND));
-		assertThrows(ApiException.class, () -> configurationService.addConfiguration("unknown", "Config.xml"));
+		assertThrows(ApiException.class, () -> configurationService.addConfigurationFile("unknown", "Config.xml"));
 	}
 
 	@Test
 	void addConfiguration_PathTraversal_ThrowsException() throws Exception {
 		ApiException exception = assertThrows(
-				ApiException.class, () -> configurationService.addConfiguration("myproject", "../../../evil.xml"));
+				ApiException.class, () -> configurationService.addConfigurationFile("myproject", "../../../evil.xml"));
 		assertEquals(HttpStatus.BAD_REQUEST, exception.getStatus());
 	}
 
@@ -391,7 +391,7 @@ class ConfigurationServiceTest {
 
 		String outsidePath = tempDir.resolve("other/evil.xml").toString();
 		ApiException exception = assertThrows(
-				ApiException.class, () -> configurationService.addConfiguration("myproject", outsidePath));
+				ApiException.class, () -> configurationService.addConfigurationFile("myproject", outsidePath));
 		assertEquals(HttpStatus.BAD_REQUEST, exception.getStatus());
 	}
 


### PR DESCRIPTION
Configuration overview now shows default Configuration.xml file that is created on default after creating a new configuration.
<img width="1533" height="1115" alt="image" src="https://github.com/user-attachments/assets/7275ccba-231e-4007-9cb4-602bc1b3c705" />

Added validation so you cannot end file or path with '/'
<img width="3824" height="1949" alt="image" src="https://github.com/user-attachments/assets/9be75301-ac0f-4c6a-9e9d-52f60523215a" />
<img width="1915" height="1303" alt="image" src="https://github.com/user-attachments/assets/a3206d30-2239-4696-9a2f-85359726e72a" />

