### PR TITLE
Refactor file tree service to separate editor and studio directory fetching logic

### DIFF
--- a/src/main/frontend/app/components/file-structure/editor-data-provider.ts
+++ b/src/main/frontend/app/components/file-structure/editor-data-provider.ts
@@ -1,6 +1,6 @@
 import type { TreeItem, TreeItemIndex } from 'react-complex-tree'
 import type { FileTreeNode } from '~/types/filesystem.types'
-import { fetchProjectRootTree, fetchDirectoryByPath } from '~/services/file-tree-service'
+import { fetchProjectRootTree, fetchEditorDirectoryByPath } from '~/services/file-tree-service'
 import { logApiError } from '~/utils/logger'
 import { sortChildren } from './tree-utilities'
 import type { DataProviderLike } from './use-file-tree-context-menu'
@@ -79,7 +79,7 @@ export default class EditorFilesDataProvider extends BaseFilesDataProvider<FileN
     if (this.loadedDirectories.has(item.data.path)) return
 
     try {
-      const directory = await fetchDirectoryByPath(this.projectName, item.data.path)
+      const directory = await fetchEditorDirectoryByPath(this.projectName, item.data.path)
       if (!directory) {
         console.warn('Received empty directory from API')
         return

--- a/src/main/frontend/app/components/file-structure/studio-files-data-provider.ts
+++ b/src/main/frontend/app/components/file-structure/studio-files-data-provider.ts
@@ -1,7 +1,7 @@
 import type { TreeItemIndex } from 'react-complex-tree'
 import { logApiError } from '~/utils/logger'
 import { sortChildren, getAncestorIds } from './tree-utilities'
-import { fetchProjectTree, fetchDirectoryByPath, fetchAncestorPath } from '~/services/file-tree-service'
+import { fetchProjectTree, fetchStudioDirectoryByPath, fetchAncestorPath } from '~/services/file-tree-service'
 import type { FileTreeNode } from '~/types/filesystem.types'
 import { BaseFilesDataProvider } from './base-files-data-provider'
 
@@ -95,7 +95,7 @@ export default class StudioFilesDataProvider extends BaseFilesDataProvider<Studi
     try {
       if (!item.children) item.children = []
 
-      const directory = await fetchDirectoryByPath(this.projectName, path)
+      const directory = await fetchStudioDirectoryByPath(this.projectName, path)
       if (!directory) {
         console.warn('Received empty directory from API')
         return

--- a/src/main/frontend/app/services/file-tree-service.ts
+++ b/src/main/frontend/app/services/file-tree-service.ts
@@ -13,12 +13,22 @@ export async function fetchProjectRootTree(projectName: string, signal?: AbortSi
   return apiFetch<FileTreeNode>(getTreeUrl(projectName), { signal })
 }
 
-export async function fetchDirectoryByPath(
+export async function fetchEditorDirectoryByPath(
   projectName: string,
   path: string,
   signal?: AbortSignal,
 ): Promise<FileTreeNode> {
-  return apiFetch<FileTreeNode>(`${getTreeUrl(projectName)}/directory?path=${encodeURIComponent(path)}`, {
+  return apiFetch<FileTreeNode>(`${getTreeUrl(projectName)}/editor/directory?path=${encodeURIComponent(path)}`, {
+    signal,
+  })
+}
+
+export async function fetchStudioDirectoryByPath(
+  projectName: string,
+  path: string,
+  signal?: AbortSignal,
+): Promise<FileTreeNode> {
+  return apiFetch<FileTreeNode>(`${getTreeUrl(projectName)}/studio/directory?path=${encodeURIComponent(path)}`, {
     signal,
   })
 }

--- a/src/main/java/org/frankframework/flow/file/FileTreeController.java
+++ b/src/main/java/org/frankframework/flow/file/FileTreeController.java
@@ -42,12 +42,20 @@ public class FileTreeController {
 		}
 	}
 
-	@GetMapping(value = "/tree/directory", params = "path")
-	public FileTreeNode getDirectoryContent(
+	@GetMapping(value = "/tree/editor/directory", params = "path")
+	public FileTreeNode getEditorDirectoryContent(
 			@PathVariable String projectName,
 			@RequestParam String path
 	) throws IOException {
 		return fileTreeService.getShallowDirectoryTree(projectName, path);
+	}
+
+	@GetMapping(value = "/tree/studio/directory", params = "path")
+	public FileTreeNode getStudioDirectoryContent(
+			@PathVariable String projectName,
+			@RequestParam String path
+	) throws IOException {
+		return fileTreeService.getShallowStudioDirectoryTree(projectName, path);
 	}
 
 	@GetMapping(value = "/tree/ancestors", params = "path")

--- a/src/main/java/org/frankframework/flow/file/FileTreeService.java
+++ b/src/main/java/org/frankframework/flow/file/FileTreeService.java
@@ -70,10 +70,15 @@ public class FileTreeService {
 		return buildShallowTree(projectDirectory.dirPath, projectDirectory.relativizeRoot, projectDirectory.useRelativePaths);
 	}
 
+	public FileTreeNode getShallowStudioDirectoryTree(String projectName, String directoryPath) throws IOException {
+		return filterStudioTree(getShallowDirectoryTree(projectName, directoryPath));
+	}
+
 	public FileTreeNode getShallowConfigurationsDirectoryTree(String projectName) throws IOException {
 		try {
 			ConfigurationDirectory configurationDirectory = getConfigurationsDirectory(projectName);
-			return buildShallowTree(configurationDirectory.directoryPath, configurationDirectory.relativizeRoot, configurationDirectory.useRelativePaths);
+			FileTreeNode tree = buildShallowTree(configurationDirectory.directoryPath, configurationDirectory.relativizeRoot, configurationDirectory.useRelativePaths);
+			return filterStudioTree(tree);
 		} catch (ApiException _) {
 			throw new IllegalArgumentException("Configurations directory does not exist: " + projectName);
 		}
@@ -82,7 +87,8 @@ public class FileTreeService {
 	public FileTreeNode getConfigurationsDirectoryTree(String projectName) throws IOException {
 		try {
 			ConfigurationDirectory configurationDirectory = getConfigurationsDirectory(projectName);
-			return buildTree(configurationDirectory.directoryPath, configurationDirectory.relativizeRoot, configurationDirectory.useRelativePaths);
+			FileTreeNode tree = buildTree(configurationDirectory.directoryPath, configurationDirectory.relativizeRoot, configurationDirectory.useRelativePaths);
+			return filterStudioTree(tree);
 		} catch (ApiException _) {
 			throw new IllegalArgumentException("Configurations directory does not exist: " + projectName);
 		}
@@ -157,6 +163,45 @@ public class FileTreeService {
 		boolean useRelativePaths = !fileSystemStorage.isLocalEnvironment();
 		Path relativizeRoot = useRelativePaths ? fileSystemStorage.toAbsolutePath("") : configurationPath;
 		return new ConfigurationDirectory(configurationPath, relativizeRoot, useRelativePaths);
+	}
+
+	/**
+	 * Prunes a tree to the nodes relevant to the Studio. Only configuration files are
+	 * kept, and a directory survives only when it (recursively) contains at least one configuration
+	 * file; directories that would end up empty are dropped so the Studio is not cluttered with folders
+	 * that hold no adapters. The supplied root node is always returned so the Studio still has a tree to
+	 * render, even when it ends up without any children.
+	 */
+	private FileTreeNode filterStudioTree(FileTreeNode root) {
+		if (root.getType() == NodeType.DIRECTORY && root.getChildren() != null) {
+			root.setChildren(pruneStudioChildren(root.getChildren()));
+		}
+		return root;
+	}
+
+	private List<FileTreeNode> pruneStudioChildren(List<FileTreeNode> children) {
+		List<FileTreeNode> kept = new ArrayList<>();
+		for (FileTreeNode child : children) {
+			if (keepStudioNode(child)) {
+				kept.add(child);
+			}
+		}
+		return kept;
+	}
+
+	private boolean keepStudioNode(FileTreeNode node) {
+		if (node.getType() == NodeType.FILE) {
+			return isStudioConfigurationFile(node.getName());
+		}
+		if (node.getChildren() == null) {
+			return true;
+		}
+		node.setChildren(pruneStudioChildren(node.getChildren()));
+		return !node.getChildren().isEmpty();
+	}
+
+	private boolean isStudioConfigurationFile(String fileName) {
+		return fileName.toLowerCase().endsWith(".xml");
 	}
 
 	private List<String> extractAdapterNames(Path xmlFile) {

--- a/src/main/java/org/frankframework/flow/file/FileTreeService.java
+++ b/src/main/java/org/frankframework/flow/file/FileTreeService.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import javax.xml.parsers.DocumentBuilder;
 import org.frankframework.flow.exception.ApiException;
@@ -166,11 +167,8 @@ public class FileTreeService {
 	}
 
 	/**
-	 * Prunes a tree to the nodes relevant to the Studio. Only configuration files are
-	 * kept, and a directory survives only when it (recursively) contains at least one configuration
-	 * file; directories that would end up empty are dropped so the Studio is not cluttered with folders
-	 * that hold no adapters. The supplied root node is always returned so the Studio still has a tree to
-	 * render, even when it ends up without any children.
+	 * Keeps only configuration files and the directories that recursively contain configuration files. The root is
+	 * always returned so the Studio has a tree to render, even when it has no children.
 	 */
 	private FileTreeNode filterStudioTree(FileTreeNode root) {
 		if (root.getType() == NodeType.DIRECTORY && root.getChildren() != null) {
@@ -180,22 +178,20 @@ public class FileTreeService {
 	}
 
 	private List<FileTreeNode> pruneStudioChildren(List<FileTreeNode> children) {
-		List<FileTreeNode> kept = new ArrayList<>();
-		for (FileTreeNode child : children) {
-			if (keepStudioNode(child)) {
-				kept.add(child);
-			}
-		}
-		return kept;
+		return children.stream()
+				.filter(this::keepStudioNode)
+				.toList();
 	}
 
 	private boolean keepStudioNode(FileTreeNode node) {
 		if (node.getType() == NodeType.FILE) {
 			return isStudioConfigurationFile(node.getName());
 		}
+
 		if (node.getChildren() == null) {
 			return true;
 		}
+
 		node.setChildren(pruneStudioChildren(node.getChildren()));
 		return !node.getChildren().isEmpty();
 	}
@@ -213,14 +209,12 @@ public class FileTreeService {
 			if (adapters.getLength() == 0) {
 				adapters = doc.getElementsByTagName("adapter");
 			}
-			List<String> names = new ArrayList<>();
-			for (int i = 0; i < adapters.getLength(); i++) {
-				String name = ((Element) adapters.item(i)).getAttribute("name");
-				if (!name.isBlank()) {
-					names.add(name);
-				}
-			}
-			return names;
+
+			NodeList resolvedAdapters = adapters;
+			return IntStream.range(0, resolvedAdapters.getLength())
+					.mapToObj(index -> ((Element) resolvedAdapters.item(index)).getAttribute("name"))
+					.filter(name -> !name.isBlank())
+					.toList();
 		} catch (Exception _) {
 			return List.of();
 		}
@@ -291,7 +285,7 @@ public class FileTreeService {
 		return node;
 	}
 
-	private ProjectDirectory resolveProjectDirectory(String projectName, String directoryPath) throws IOException {
+	private ProjectDirectory resolveProjectDirectory(String projectName, String directoryPath) {
 		try {
 			ConfigurationProject configurationProject = configurationProjectService.getProject(projectName);
 			Path projectPath = fileSystemStorage.toAbsolutePath(configurationProject.getRootPath());

--- a/src/test/java/org/frankframework/flow/file/FileTreeControllerTest.java
+++ b/src/test/java/org/frankframework/flow/file/FileTreeControllerTest.java
@@ -87,11 +87,53 @@ class FileTreeControllerTest {
 	}
 
 	@Test
-	void getDirectoryContentRequiresPathParameter() throws Exception {
-		mockMvc.perform(get("/api/projects/MyProject/tree/directory"))
+	void getEditorDirectoryContentRequiresPathParameter() throws Exception {
+		mockMvc.perform(get("/api/projects/MyProject/tree/editor/directory"))
 				.andExpect(status().isBadRequest());
 
 		verify(fileTreeService, never()).getShallowDirectoryTree("MyProject", "");
+	}
+
+	@Test
+	void getStudioDirectoryContentRequiresPathParameter() throws Exception {
+		mockMvc.perform(get("/api/projects/MyProject/tree/studio/directory"))
+				.andExpect(status().isBadRequest());
+
+		verify(fileTreeService, never()).getShallowStudioDirectoryTree("MyProject", "");
+	}
+
+	@Test
+	void getEditorDirectoryContentReturnsUnfilteredTree() throws Exception {
+		FileTreeNode treeNode = new FileTreeNode();
+		treeNode.setName("MyConfig");
+		treeNode.setPath("configurations/MyConfig");
+		treeNode.setType(NodeType.DIRECTORY);
+
+		when(fileTreeService.getShallowDirectoryTree("MyProject", "configurations/MyConfig"))
+				.thenReturn(treeNode);
+
+		mockMvc.perform(get("/api/projects/MyProject/tree/editor/directory").param("path", "configurations/MyConfig"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.name").value("MyConfig"));
+
+		verify(fileTreeService).getShallowDirectoryTree("MyProject", "configurations/MyConfig");
+	}
+
+	@Test
+	void getStudioDirectoryContentReturnsFilteredTree() throws Exception {
+		FileTreeNode treeNode = new FileTreeNode();
+		treeNode.setName("MyConfig");
+		treeNode.setPath("configurations/MyConfig");
+		treeNode.setType(NodeType.DIRECTORY);
+
+		when(fileTreeService.getShallowStudioDirectoryTree("MyProject", "configurations/MyConfig"))
+				.thenReturn(treeNode);
+
+		mockMvc.perform(get("/api/projects/MyProject/tree/studio/directory").param("path", "configurations/MyConfig"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.name").value("MyConfig"));
+
+		verify(fileTreeService).getShallowStudioDirectoryTree("MyProject", "configurations/MyConfig");
 	}
 
 	@Test

--- a/src/test/java/org/frankframework/flow/file/FileTreeServiceTest.java
+++ b/src/test/java/org/frankframework/flow/file/FileTreeServiceTest.java
@@ -145,6 +145,30 @@ public class FileTreeServiceTest {
 	}
 
 	@Test
+	@DisplayName("Studio directory tree should strip non-configuration files but keep subfolders")
+	public void getShallowStudioDirectoryTreeFiltersNonConfigurationFiles() throws IOException, ApiException {
+		stubToAbsolutePath();
+
+		Files.writeString(tempProjectRoot.resolve("config1.xml"), "<config/>");
+		Files.writeString(tempProjectRoot.resolve("readme.txt"), "hello");
+		Files.writeString(tempProjectRoot.resolve("application.properties"), "key=value");
+		Files.createDirectory(tempProjectRoot.resolve("subfolder"));
+
+		ConfigurationProject configurationProject =
+				new ConfigurationProject(TEST_PROJECT_NAME, tempProjectRoot.toAbsolutePath().toString());
+		when(configurationProjectService.getProject(TEST_PROJECT_NAME)).thenReturn(configurationProject);
+
+		FileTreeNode node = fileTreeService.getShallowStudioDirectoryTree(TEST_PROJECT_NAME, ".");
+
+		assertNotNull(node);
+		assertEquals(2, node.getChildren().size());
+		assertTrue(node.getChildren().stream().anyMatch(childNode -> childNode.getName().equals("config1.xml")));
+		assertTrue(node.getChildren().stream().anyMatch(childNode -> childNode.getName().equals("subfolder")));
+		assertFalse(node.getChildren().stream().anyMatch(childNode -> childNode.getName().equals("readme.txt")));
+		assertFalse(node.getChildren().stream().anyMatch(childNode -> childNode.getName().equals("application.properties")));
+	}
+
+	@Test
 	void getShallowDirectoryTreeThrowsSecurityExceptionForPathTraversal() throws ApiException {
 		stubToAbsolutePath();
 
@@ -191,10 +215,10 @@ public class FileTreeServiceTest {
 		assertEquals(TEST_PROJECT_NAME, node.getName());
 		assertEquals(NodeType.DIRECTORY, node.getType());
 		assertNotNull(node.getChildren());
-		assertEquals(2, node.getChildren().size());
+		assertEquals(1, node.getChildren().size());
 
 		assertTrue(node.getChildren().stream().anyMatch(childNode -> childNode.getName().equals("config1.xml")));
-		assertTrue(node.getChildren().stream().anyMatch(childNode -> childNode.getName().equals("readme.txt")));
+		assertFalse(node.getChildren().stream().anyMatch(childNode -> childNode.getName().equals("readme.txt")));
 	}
 
 	@Test
@@ -235,6 +259,11 @@ public class FileTreeServiceTest {
 		Path subDir = tempConfigurationRoot.resolve("subconfigs");
 		Files.createDirectory(subDir);
 		Files.writeString(subDir.resolve("nested.xml"), "<nested></nested>");
+		Files.writeString(subDir.resolve("notes.txt"), "ignored");
+		Files.createDirectory(tempConfigurationRoot.resolve("emptyDir"));
+		Path docsOnly = tempConfigurationRoot.resolve("docsOnly");
+		Files.createDirectory(docsOnly);
+		Files.writeString(docsOnly.resolve("guide.md"), "# guide");
 
 		ConfigurationProject configurationProject = new ConfigurationProject(TEST_PROJECT_NAME, tempConfigurationRoot.toAbsolutePath().toString());
 		when(configurationProjectService.getProject(TEST_PROJECT_NAME)).thenReturn(configurationProject);
@@ -245,10 +274,12 @@ public class FileTreeServiceTest {
 		assertEquals(TEST_PROJECT_NAME, node.getName());
 		assertEquals(NodeType.DIRECTORY, node.getType());
 		assertNotNull(node.getChildren());
-		assertEquals(3, node.getChildren().size());
+		assertEquals(2, node.getChildren().size());
 
 		assertTrue(node.getChildren().stream().anyMatch(childNode -> childNode.getName().equals("config1.xml")));
-		assertTrue(node.getChildren().stream().anyMatch(childNode -> childNode.getName().equals("readme.txt")));
+		assertFalse(node.getChildren().stream().anyMatch(childNode -> childNode.getName().equals("readme.txt")));
+		assertFalse(node.getChildren().stream().anyMatch(childNode -> childNode.getName().equals("emptyDir")));
+		assertFalse(node.getChildren().stream().anyMatch(childNode -> childNode.getName().equals("docsOnly")));
 
 		FileTreeNode subConfigNode = node.getChildren().stream()
 				.filter(c -> c.getName().equals("subconfigs"))


### PR DESCRIPTION
**Studio (Only configuration files)**
<img width="3837" height="1958" alt="image" src="https://github.com/user-attachments/assets/c7973cef-d26f-49a1-b29d-8396b002df5b" />
<img width="3834" height="1953" alt="image" src="https://github.com/user-attachments/assets/961c5977-f4de-4ad4-a87c-cc7912c22c62" />


**Editor (Eveything)**
<img width="3833" height="2022" alt="image" src="https://github.com/user-attachments/assets/c620b8d3-c8a2-4e87-a62a-4f08f229a1dc" />
<img width="3831" height="1959" alt="image" src="https://github.com/user-attachments/assets/acb45416-6d28-48a8-817d-b29ce74dd4b2" />