### PR TITLE
Add flow namespace repair functionality and Modules can have root flow namespace now

### DIFF
--- a/src/main/java/org/frankframework/flow/configuration/ConfigurationService.java
+++ b/src/main/java/org/frankframework/flow/configuration/ConfigurationService.java
@@ -124,7 +124,7 @@ public class ConfigurationService {
 			return xml;
 		}
 
-		return xml.replaceFirst("(<(?:Configuration|Module))\\b", "$1 xmlns:flow=\"urn:frank-flow\"");
+		return XmlConfigurationUtils.addFlowNamespaceDeclaration(xml);
 	}
 
 	private String loadDefaultConfigurationXml() throws IOException {

--- a/src/main/java/org/frankframework/flow/configuration/ConfigurationService.java
+++ b/src/main/java/org/frankframework/flow/configuration/ConfigurationService.java
@@ -63,6 +63,9 @@ public class ConfigurationService {
 		}
 
 		String content = fileSystemStorage.readFile(filePath.toString());
+		// Repair configurations that were saved with undeclared flow:* layout metadata (e.g. <Module>
+		// roots) so the studio can parse and open their adapters again.
+		content = XmlConfigurationUtils.repairFlowNamespace(content);
 		return new ConfigurationDTO(filepath, content);
 	}
 
@@ -123,7 +126,7 @@ public class ConfigurationService {
 			return xml;
 		}
 
-		return xml.replaceFirst("(<Configuration)\\b", "$1 xmlns:flow=\"urn:frank-flow\"");
+		return xml.replaceFirst("(<(?:Configuration|Module))\\b", "$1 xmlns:flow=\"urn:frank-flow\"");
 	}
 
 	private String loadDefaultConfigurationXml() throws IOException {

--- a/src/main/java/org/frankframework/flow/configuration/ConfigurationService.java
+++ b/src/main/java/org/frankframework/flow/configuration/ConfigurationService.java
@@ -63,8 +63,6 @@ public class ConfigurationService {
 		}
 
 		String content = fileSystemStorage.readFile(filePath.toString());
-		// Repair configurations that were saved with undeclared flow:* layout metadata (e.g. <Module>
-		// roots) so the studio can parse and open their adapters again.
 		content = XmlConfigurationUtils.repairFlowNamespace(content);
 		return new ConfigurationDTO(filepath, content);
 	}

--- a/src/main/java/org/frankframework/flow/file/FileTreeService.java
+++ b/src/main/java/org/frankframework/flow/file/FileTreeService.java
@@ -1,7 +1,9 @@
 package org.frankframework.flow.file;
 
 import java.io.IOException;
+import java.io.StringReader;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -14,11 +16,13 @@ import org.frankframework.flow.exception.ApiException;
 import org.frankframework.flow.filesystem.FileSystemStorage;
 import org.frankframework.flow.project.ConfigurationProject;
 import org.frankframework.flow.project.ConfigurationProjectService;
+import org.frankframework.flow.utility.XmlConfigurationUtils;
 import org.frankframework.flow.utility.XmlSecurityUtils;
 import org.springframework.stereotype.Service;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
 import org.xml.sax.helpers.DefaultHandler;
 
 @Service
@@ -161,9 +165,10 @@ public class FileTreeService {
 
 	private List<String> extractAdapterNames(Path xmlFile) {
 		try {
+			String content = XmlConfigurationUtils.repairFlowNamespace(Files.readString(xmlFile, StandardCharsets.UTF_8));
 			DocumentBuilder builder = XmlSecurityUtils.createSecureDocumentBuilder();
 			builder.setErrorHandler(new DefaultHandler());
-			Document doc = builder.parse(Files.newInputStream(xmlFile));
+			Document doc = builder.parse(new InputSource(new StringReader(content)));
 			NodeList adapters = doc.getElementsByTagName("Adapter");
 			if (adapters.getLength() == 0) {
 				adapters = doc.getElementsByTagName("adapter");

--- a/src/main/java/org/frankframework/flow/utility/XmlConfigurationUtils.java
+++ b/src/main/java/org/frankframework/flow/utility/XmlConfigurationUtils.java
@@ -3,6 +3,8 @@ package org.frankframework.flow.utility;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.util.List;
+import java.util.regex.Pattern;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
@@ -16,6 +18,14 @@ import org.xml.sax.SAXException;
 
 @UtilityClass
 public class XmlConfigurationUtils {
+
+	private static final List<String> ROOT_ELEMENTS = List.of("Configuration", "Module");
+	private static final String FLOW_NAMESPACE_QNAME = "xmlns:flow";
+	private static final String FLOW_NAMESPACE_URI = "urn:frank-flow";
+	private static final Pattern ROOT_ELEMENT_PATTERN =
+			Pattern.compile("(<(?:" + String.join("|", ROOT_ELEMENTS) + "))\\b");
+	private static final String FLOW_NAMESPACE_REPLACEMENT =
+			"$1 " + FLOW_NAMESPACE_QNAME + "=\"" + FLOW_NAMESPACE_URI + "\"";
 
 	/**
 	 * Checks if a configuration document has the flow namespace included.
@@ -32,13 +42,15 @@ public class XmlConfigurationUtils {
 
 		Document configDoc = builder.parse(new InputSource(new StringReader(configurationXml)));
 
-		NodeList configurationNodes = configDoc.getElementsByTagName("Configuration");
+		for (String rootElement : ROOT_ELEMENTS) {
+			NodeList rootNodes = configDoc.getElementsByTagName(rootElement);
 
-		for (int i = 0; i < configurationNodes.getLength(); i++) {
-			Element configuration = (Element) configurationNodes.item(i);
+			for (int i = 0; i < rootNodes.getLength(); i++) {
+				Element root = (Element) rootNodes.item(i);
 
-			if (!configuration.hasAttribute("xmlns:flow")) {
-				configuration.setAttributeNS(XMLConstants.XMLNS_ATTRIBUTE_NS_URI, "xmlns:flow", "urn:frank-flow");
+				if (!root.hasAttribute(FLOW_NAMESPACE_QNAME)) {
+					root.setAttributeNS(XMLConstants.XMLNS_ATTRIBUTE_NS_URI, FLOW_NAMESPACE_QNAME, FLOW_NAMESPACE_URI);
+				}
 			}
 		}
 
@@ -47,17 +59,25 @@ public class XmlConfigurationUtils {
 
 	public static String repairFlowNamespace(String configurationXml) {
 		if (configurationXml == null
-				|| configurationXml.contains("xmlns:flow")
+				|| configurationXml.contains(FLOW_NAMESPACE_QNAME)
 				|| !configurationXml.contains("flow:")) {
 			return configurationXml;
 		}
 
-		return configurationXml.replaceFirst("(<(?:Configuration|Module))\\b", "$1 xmlns:flow=\"urn:frank-flow\"");
+		return addFlowNamespaceDeclaration(configurationXml);
+	}
+
+	/**
+	 * Adds the {@code xmlns:flow} declaration to the first supported root element (see {@link #ROOT_ELEMENTS}).
+	 * Callers are responsible for first checking that the declaration is actually missing.
+	 */
+	public static String addFlowNamespaceDeclaration(String configurationXml) {
+		return ROOT_ELEMENT_PATTERN.matcher(configurationXml).replaceFirst(FLOW_NAMESPACE_REPLACEMENT);
 	}
 
 	/**
 	 * Converts a DOM Node to a formatted XML string.
-	 * @throws TransformerException
+	 * @throws TransformerException if an error occurs during transformation
 	 */
 	public static String convertNodeToString(Node node) throws TransformerException {
 		Transformer transformer =

--- a/src/main/java/org/frankframework/flow/utility/XmlConfigurationUtils.java
+++ b/src/main/java/org/frankframework/flow/utility/XmlConfigurationUtils.java
@@ -45,6 +45,16 @@ public class XmlConfigurationUtils {
 		return configDoc;
 	}
 
+	public static String repairFlowNamespace(String configurationXml) {
+		if (configurationXml == null
+				|| configurationXml.contains("xmlns:flow")
+				|| !configurationXml.contains("flow:")) {
+			return configurationXml;
+		}
+
+		return configurationXml.replaceFirst("(<(?:Configuration|Module))\\b", "$1 xmlns:flow=\"urn:frank-flow\"");
+	}
+
 	/**
 	 * Converts a DOM Node to a formatted XML string.
 	 * @throws TransformerException

--- a/src/test/java/org/frankframework/flow/configuration/ConfigurationServiceTest.java
+++ b/src/test/java/org/frankframework/flow/configuration/ConfigurationServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -18,6 +19,7 @@ import org.frankframework.flow.frankconfig.FrankConfigXsdService;
 import org.frankframework.flow.project.ConfigurationProject;
 import org.frankframework.flow.project.ConfigurationProjectService;
 import org.frankframework.flow.utility.XmlFormatterUtils;
+import org.frankframework.flow.utility.XmlSecurityUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,6 +28,9 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 
 @ExtendWith(MockitoExtension.class)
 class ConfigurationServiceTest {
@@ -187,6 +192,86 @@ class ConfigurationServiceTest {
 
 		assertEquals(content, result);
 		verify(fileSystemStorage).writeFile(eq(file.toString()), eq(content));
+	}
+
+	@Test
+	void updateConfiguration_FormatFalse_AddsFlowNamespaceToModuleRoot() throws Exception {
+		stubToAbsolutePath();
+		stubWriteFile();
+
+		Path file = tempDir.resolve("config.xml");
+		Files.writeString(file, "<Module/>", StandardCharsets.UTF_8);
+
+		String result = configurationService.updateConfiguration("test", file.toString(), "<Module/>", false);
+
+		assertTrue(
+				result.contains("xmlns:flow=\"urn:frank-flow\""),
+				"flow namespace should be declared on <Module> roots"
+		);
+	}
+
+	@Test
+	void getConfigurationContent_RepairsUndeclaredFlowNamespace() throws Exception {
+		stubToAbsolutePath();
+		stubReadFile();
+
+		// A configuration previously corrupted by the studio: flow:* layout metadata but no
+		// xmlns:flow declaration. Reading it must heal it so the adapter can be opened again.
+		Path file = tempDir.resolve("config.xml");
+		Files.writeString(
+				file,
+				"<Module><Adapter name=\"MyAdapter\"><Pipeline><EchoPipe name=\"Result\" flow:x=\"10\"/></Pipeline></Adapter></Module>",
+				StandardCharsets.UTF_8
+		);
+
+		ConfigurationDTO result = configurationService.getConfigurationContent("test", file.toString());
+
+		assertTrue(result.content().contains("xmlns:flow=\"urn:frank-flow\""));
+
+		Document doc = XmlSecurityUtils.createSecureDocumentBuilder()
+				.parse(new ByteArrayInputStream(result.content().getBytes(StandardCharsets.UTF_8)));
+		assertEquals("MyAdapter", ((Element) doc.getElementsByTagName("Adapter").item(0)).getAttribute("name"));
+	}
+
+	@Test
+	void getConfigurationContent_LeavesCleanConfigurationUnchanged() throws Exception {
+		stubToAbsolutePath();
+		stubReadFile();
+
+		String original = "<Configuration><Adapter name=\"A\"/></Configuration>";
+		Path file = tempDir.resolve("config.xml");
+		Files.writeString(file, original, StandardCharsets.UTF_8);
+
+		ConfigurationDTO result = configurationService.getConfigurationContent("test", file.toString());
+
+		assertEquals(original, result.content());
+	}
+
+	@Test
+	void updateConfiguration_FormatTrue_ModuleRootWithFlowAttributes_StaysNamespaceAwareParseable() throws Exception {
+		stubToAbsolutePath();
+		stubWriteFile();
+
+		Path file = tempDir.resolve("config.xml");
+		Files.writeString(file, "<Module/>", StandardCharsets.UTF_8);
+
+		String studioOutput = "<Module>"
+				+ "<Adapter name=\"MyAdapter\">"
+				+ "<Pipeline>"
+				+ "<EchoPipe name=\"Result\" flow:x=\"10\" flow:y=\"20\" flow:width=\"200\"/>"
+				+ "</Pipeline>"
+				+ "</Adapter>"
+				+ "</Module>";
+
+		String result = configurationService.updateConfiguration("test", file.toString(), studioOutput, true);
+
+		assertTrue(result.contains("xmlns:flow=\"urn:frank-flow\""));
+
+		Document doc = XmlSecurityUtils.createSecureDocumentBuilder()
+				.parse(new ByteArrayInputStream(result.getBytes(StandardCharsets.UTF_8)));
+		NodeList adapters = doc.getElementsByTagName("Adapter");
+		assertEquals(1, adapters.getLength(), "adapter must remain recognizable after a studio save");
+		assertEquals("MyAdapter", ((Element) adapters.item(0)).getAttribute("name"));
 	}
 
 	@Test

--- a/src/test/java/org/frankframework/flow/configuration/ConfigurationServiceTest.java
+++ b/src/test/java/org/frankframework/flow/configuration/ConfigurationServiceTest.java
@@ -215,8 +215,6 @@ class ConfigurationServiceTest {
 		stubToAbsolutePath();
 		stubReadFile();
 
-		// A configuration previously corrupted by the studio: flow:* layout metadata but no
-		// xmlns:flow declaration. Reading it must heal it so the adapter can be opened again.
 		Path file = tempDir.resolve("config.xml");
 		Files.writeString(
 				file,

--- a/src/test/java/org/frankframework/flow/utility/XmlConfigurationUtilsTest.java
+++ b/src/test/java/org/frankframework/flow/utility/XmlConfigurationUtilsTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.*;
 
 import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -78,15 +80,13 @@ class XmlConfigurationUtilsTest {
 
 	@Test
 	void insertFlowNamespace_returnsNullForNullInput() throws Exception {
-		assertNull(XmlConfigurationUtils.insertFlowNamespace(null));
+		Assertions.assertNull(XmlConfigurationUtils.insertFlowNamespace(null));
 	}
 
 	@Test
 	void insertFlowNamespace_returnsNullForBlankInput() throws Exception {
-		assertNull(XmlConfigurationUtils.insertFlowNamespace("   "));
+		Assertions.assertNull(XmlConfigurationUtils.insertFlowNamespace("   "));
 	}
-
-	// ── repairFlowNamespace ──
 
 	@Test
 	void repairFlowNamespace_addsNamespaceToModuleRootWithUndeclaredPrefix() {
@@ -122,6 +122,6 @@ class XmlConfigurationUtilsTest {
 
 	@Test
 	void repairFlowNamespace_returnsNullForNullInput() {
-		assertNull(XmlConfigurationUtils.repairFlowNamespace(null));
+		Assertions.assertNull(XmlConfigurationUtils.repairFlowNamespace(null));
 	}
 }

--- a/src/test/java/org/frankframework/flow/utility/XmlConfigurationUtilsTest.java
+++ b/src/test/java/org/frankframework/flow/utility/XmlConfigurationUtilsTest.java
@@ -58,6 +58,16 @@ class XmlConfigurationUtilsTest {
 	}
 
 	@Test
+	void insertFlowNamespace_addsNamespaceToModuleRoot() throws Exception {
+		String xml = "<Module><Adapter name=\"A\"/></Module>";
+
+		Document updated = XmlConfigurationUtils.insertFlowNamespace(xml);
+
+		Element module = updated.getDocumentElement();
+		assertEquals("urn:frank-flow", module.getAttribute("xmlns:flow"));
+	}
+
+	@Test
 	void insertFlowNamespace_doesNotDuplicateWhenAlreadyPresent() throws Exception {
 		String xml = "<Configuration name=\"TestConfig\" xmlns:flow=\"urn:frank-flow\"><Adapter name=\"A\"/></Configuration>";
 

--- a/src/test/java/org/frankframework/flow/utility/XmlConfigurationUtilsTest.java
+++ b/src/test/java/org/frankframework/flow/utility/XmlConfigurationUtilsTest.java
@@ -85,4 +85,43 @@ class XmlConfigurationUtilsTest {
 	void insertFlowNamespace_returnsNullForBlankInput() throws Exception {
 		assertNull(XmlConfigurationUtils.insertFlowNamespace("   "));
 	}
+
+	// ── repairFlowNamespace ──
+
+	@Test
+	void repairFlowNamespace_addsNamespaceToModuleRootWithUndeclaredPrefix() {
+		String xml = "<Module><Adapter name=\"A\"><Pipeline><EchoPipe name=\"R\" flow:x=\"1\"/></Pipeline></Adapter></Module>";
+
+		String result = XmlConfigurationUtils.repairFlowNamespace(xml);
+
+		assertTrue(result.contains("<Module xmlns:flow=\"urn:frank-flow\">"));
+	}
+
+	@Test
+	void repairFlowNamespace_addsNamespaceToConfigurationRootWithUndeclaredPrefix() {
+		String xml = "<Configuration name=\"C\"><Adapter name=\"A\" flow:x=\"1\"/></Configuration>";
+
+		String result = XmlConfigurationUtils.repairFlowNamespace(xml);
+
+		assertTrue(result.contains("<Configuration xmlns:flow=\"urn:frank-flow\""));
+	}
+
+	@Test
+	void repairFlowNamespace_leavesXmlWithDeclaredNamespaceUnchanged() {
+		String xml = "<Module xmlns:flow=\"urn:frank-flow\"><Adapter name=\"A\" flow:x=\"1\"/></Module>";
+
+		assertEquals(xml, XmlConfigurationUtils.repairFlowNamespace(xml));
+	}
+
+	@Test
+	void repairFlowNamespace_leavesXmlWithoutFlowMarkupUnchanged() {
+		String xml = "<Module><Adapter name=\"A\"/></Module>";
+
+		assertEquals(xml, XmlConfigurationUtils.repairFlowNamespace(xml));
+	}
+
+	@Test
+	void repairFlowNamespace_returnsNullForNullInput() {
+		assertNull(XmlConfigurationUtils.repairFlowNamespace(null));
+	}
 }

--- a/src/test/java/org/frankframework/flow/utility/XmlConfigurationUtilsTest.java
+++ b/src/test/java/org/frankframework/flow/utility/XmlConfigurationUtilsTest.java
@@ -1,10 +1,8 @@
 package org.frankframework.flow.utility;
 
-import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.*;
 
 import javax.xml.parsers.DocumentBuilderFactory;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;


### PR DESCRIPTION
- Modules now also are configured as possible root elements and also can have flow namespaced elements
- Broken configurations are auto repaired if they have this problem now.

<img width="2591" height="1844" alt="image" src="https://github.com/user-attachments/assets/97ad4615-b31f-424b-834e-153e59d62e30" />
