### PR TITLE
Enhance flow handling by integrating forwards dynamically

### DIFF
--- a/src/main/frontend/app/hooks/use-handle-types.spec.ts
+++ b/src/main/frontend/app/hooks/use-handle-types.spec.ts
@@ -1,0 +1,25 @@
+import { getHandleTypes } from './use-handle-types'
+
+describe('getHandleTypes', () => {
+  it('returns empty array when typesAllowed is undefined', () => {
+    expect(getHandleTypes()).toEqual([])
+  })
+
+  it('returns empty array when typesAllowed is empty', () => {
+    expect(getHandleTypes({})).toEqual([])
+  })
+
+  it('returns all forwards as-is', () => {
+    const result = getHandleTypes({ success: {}, exception: {}, failure: {} })
+    expect(result).toContain('success')
+    expect(result).toContain('exception')
+    expect(result).toContain('failure')
+  })
+
+  it('maps wildcard * to custom', () => {
+    const result = getHandleTypes({ '*': {}, exception: {} })
+    expect(result).toContain('custom')
+    expect(result).toContain('exception')
+    expect(result).not.toContain('*')
+  })
+})

--- a/src/main/frontend/app/hooks/use-handle-types.ts
+++ b/src/main/frontend/app/hooks/use-handle-types.ts
@@ -1,23 +1,12 @@
 import { useMemo } from 'react'
 import type { ElementProperty } from '@frankframework/doc-library-core'
 
+export function getHandleTypes(typesAllowed?: Record<string, ElementProperty>): string[] {
+  if (!typesAllowed) return []
+
+  return Object.keys(typesAllowed).flatMap((type) => (type === '*' ? ['custom'] : [type]))
+}
+
 export function useHandleTypes(typesAllowed?: Record<string, ElementProperty>) {
-  return useMemo(() => {
-    // Always include the 'success' handle, using a Set to avoid duplicates
-    const handles = new Set<string>(['success'])
-
-    if (!typesAllowed) return [...handles]
-
-    if ('*' in typesAllowed) {
-      handles.add('custom')
-    }
-
-    for (const type of Object.keys(typesAllowed)) {
-      if (type !== '*') {
-        handles.add(type)
-      }
-    }
-
-    return [...handles]
-  }, [typesAllowed])
+  return useMemo(() => getHandleTypes(typesAllowed), [typesAllowed])
 }

--- a/src/main/frontend/app/routes/studio/canvas/flow.tsx
+++ b/src/main/frontend/app/routes/studio/canvas/flow.tsx
@@ -200,7 +200,7 @@ function FlowCanvas({ onOpenInEditor }: { onOpenInEditor: () => void }) {
       setSelectedGroupId: store.setSelectedGroupId,
     })),
   )
-  const { elements, ffDoc } = useFFDoc()
+  const { elements } = useFFDoc()
   const elementsRef = useRef(elements)
   const showNodeContextMenuRef = useRef(showNodeContextMenu)
   const navigate = useNavigate()
@@ -1001,16 +1001,12 @@ function FlowCanvas({ onOpenInEditor }: { onOpenInEditor: () => void }) {
   )
 
   const resolveForwards = useCallback(
-    (subtype: string) => {
-      const element = lookupFrankElement(subtype)
-      if (!element || !ffDoc) return element?.forwards
-      return resolveForwardsWithInheritance(element.forwards, ffDoc.elements)
-    },
-    [lookupFrankElement, ffDoc],
+    (subtype: string) => resolveForwardsWithInheritance(lookupFrankElement(subtype)?.forwards),
+    [lookupFrankElement],
   )
 
-  const importForwardsResolverRef = useRef<ResolveForwards | undefined>(undefined)
-  importForwardsResolverRef.current = ffDoc ? resolveForwards : undefined
+  const importForwardsResolverRef = useRef<ResolveForwards>(resolveForwards)
+  importForwardsResolverRef.current = resolveForwards
 
   const deselectOtherNodes = useCallback(
     (nodeId: string) => {
@@ -1261,10 +1257,7 @@ function FlowCanvas({ onOpenInEditor }: { onOpenInEditor: () => void }) {
     const width = nodeType === 'exitNode' ? FlowConfig.EXIT_DEFAULT_WIDTH : FlowConfig.NODE_DEFAULT_WIDTH
     const height = nodeType === 'exitNode' ? FlowConfig.EXIT_DEFAULT_HEIGHT : FlowConfig.NODE_MIN_HEIGHT
 
-    const sourceHandles =
-      nodeType === 'frankNode' && ffDoc
-        ? getDefaultSourceHandles(resolveForwards(elementName))
-        : [{ type: 'success', index: 1 }]
+    const sourceHandles = getDefaultSourceHandles(resolveForwards(elementName))
 
     const newNode: FrankNodeType = {
       id: newId.toString(),

--- a/src/main/frontend/app/routes/studio/canvas/flow.tsx
+++ b/src/main/frontend/app/routes/studio/canvas/flow.tsx
@@ -200,7 +200,7 @@ function FlowCanvas({ onOpenInEditor }: { onOpenInEditor: () => void }) {
       setSelectedGroupId: store.setSelectedGroupId,
     })),
   )
-  const { elements } = useFFDoc()
+  const { elements, ffDoc } = useFFDoc()
   const elementsRef = useRef(elements)
   const showNodeContextMenuRef = useRef(showNodeContextMenu)
   const navigate = useNavigate()
@@ -1001,8 +1001,8 @@ function FlowCanvas({ onOpenInEditor }: { onOpenInEditor: () => void }) {
   )
 
   const resolveForwards = useCallback(
-    (subtype: string) => resolveForwardsWithInheritance(lookupFrankElement(subtype)),
-    [lookupFrankElement],
+    (subtype: string) => resolveForwardsWithInheritance(lookupFrankElement(subtype), ffDoc?.elements, ffDoc?.enums),
+    [lookupFrankElement, ffDoc],
   )
 
   const importForwardsResolverRef = useRef<ResolveForwards>(resolveForwards)

--- a/src/main/frontend/app/routes/studio/canvas/flow.tsx
+++ b/src/main/frontend/app/routes/studio/canvas/flow.tsx
@@ -1001,7 +1001,7 @@ function FlowCanvas({ onOpenInEditor }: { onOpenInEditor: () => void }) {
   )
 
   const resolveForwards = useCallback(
-    (subtype: string) => resolveForwardsWithInheritance(lookupFrankElement(subtype)?.forwards),
+    (subtype: string) => resolveForwardsWithInheritance(lookupFrankElement(subtype)),
     [lookupFrankElement],
   )
 

--- a/src/main/frontend/app/routes/studio/canvas/flow.tsx
+++ b/src/main/frontend/app/routes/studio/canvas/flow.tsx
@@ -35,12 +35,17 @@ import { logApiError } from '~/utils/logger'
 import { NodeContextMenuContext, useNodeContextMenu } from './node-context-menu-context'
 import StickyNoteComponent, { type StickyNote } from '~/routes/studio/canvas/nodetypes/sticky-note'
 import useTabStore, { type TabData } from '~/stores/tab-store'
-import { convertAdapterXmlToJson, getAdapterFromConfiguration } from '~/routes/studio/xml-to-json-parser'
+import {
+  convertAdapterXmlToJson,
+  getAdapterFromConfiguration,
+  type ResolveForwards,
+} from '~/routes/studio/xml-to-json-parser'
 import { exportFlowToXml, replaceAdapterInXml } from '~/routes/studio/flow-to-xml-parser'
 import useNodeContextStore from '~/stores/node-context-store'
 import CreateNodeModal from '~/components/flow/create-node-modal'
 import { useFFDoc } from '@frankframework/doc-library-react'
 import type { ElementDetails } from '@frankframework/doc-library-core'
+import { getDefaultSourceHandles, resolveForwardsWithInheritance } from '~/utils/frankdoc-utils'
 import { useProjectStore } from '~/stores/project-store'
 import {
   clearConfigurationFileCache,
@@ -195,7 +200,7 @@ function FlowCanvas({ onOpenInEditor }: { onOpenInEditor: () => void }) {
       setSelectedGroupId: store.setSelectedGroupId,
     })),
   )
-  const { elements } = useFFDoc()
+  const { elements, ffDoc } = useFFDoc()
   const elementsRef = useRef(elements)
   const showNodeContextMenuRef = useRef(showNodeContextMenu)
   const navigate = useNavigate()
@@ -995,6 +1000,18 @@ function FlowCanvas({ onOpenInEditor }: { onOpenInEditor: () => void }) {
     [elements],
   )
 
+  const resolveForwards = useCallback(
+    (subtype: string) => {
+      const element = lookupFrankElement(subtype)
+      if (!element || !ffDoc) return element?.forwards
+      return resolveForwardsWithInheritance(element.forwards, ffDoc.elements)
+    },
+    [lookupFrankElement, ffDoc],
+  )
+
+  const importForwardsResolverRef = useRef<ResolveForwards | undefined>(undefined)
+  importForwardsResolverRef.current = ffDoc ? resolveForwards : undefined
+
   const deselectOtherNodes = useCallback(
     (nodeId: string) => {
       const flowNodes = reactFlow.getNodes()
@@ -1244,6 +1261,11 @@ function FlowCanvas({ onOpenInEditor }: { onOpenInEditor: () => void }) {
     const width = nodeType === 'exitNode' ? FlowConfig.EXIT_DEFAULT_WIDTH : FlowConfig.NODE_DEFAULT_WIDTH
     const height = nodeType === 'exitNode' ? FlowConfig.EXIT_DEFAULT_HEIGHT : FlowConfig.NODE_MIN_HEIGHT
 
+    const sourceHandles =
+      nodeType === 'frankNode' && ffDoc
+        ? getDefaultSourceHandles(resolveForwards(elementName))
+        : [{ type: 'success', index: 1 }]
+
     const newNode: FrankNodeType = {
       id: newId.toString(),
       position: {
@@ -1254,7 +1276,7 @@ function FlowCanvas({ onOpenInEditor }: { onOpenInEditor: () => void }) {
         subtype: elementName,
         type: elementType,
         name: ``,
-        sourceHandles: [{ type: 'success', index: 1 }],
+        sourceHandles,
         children: [],
       },
       type: nodeType,
@@ -1491,7 +1513,7 @@ function FlowCanvas({ onOpenInEditor }: { onOpenInEditor: () => void }) {
         tab.adapterPosition,
       )
       if (!adapter) return
-      const adapterJson = await convertAdapterXmlToJson(adapter)
+      const adapterJson = await convertAdapterXmlToJson(adapter, importForwardsResolverRef.current)
 
       flowStore.setEdges(adapterJson.edges)
       flowStore.setNodes(adapterJson.nodes)
@@ -1737,10 +1759,7 @@ function FlowCanvas({ onOpenInEditor }: { onOpenInEditor: () => void }) {
             position={pendingCompactConnection.position}
             onClose={() => setPendingCompactConnection(null)}
             onSelect={handleCompactHandleSelect}
-            typesAllowed={
-              (elements as Record<string, ElementDetails> | null)?.[pendingCompactConnection.sourceNodeSubtype]
-                ?.forwards
-            }
+            typesAllowed={resolveForwards(pendingCompactConnection.sourceNodeSubtype)}
           />
         )}
 
@@ -1750,9 +1769,7 @@ function FlowCanvas({ onOpenInEditor }: { onOpenInEditor: () => void }) {
             position={pendingEdgeDrop.position}
             onClose={() => setPendingEdgeDrop(null)}
             onSelect={handleEdgeDropHandleSelect}
-            typesAllowed={
-              (elements as Record<string, ElementDetails> | null)?.[pendingEdgeDrop.sourceNodeSubtype]?.forwards
-            }
+            typesAllowed={resolveForwards(pendingEdgeDrop.sourceNodeSubtype)}
           />
         )}
 

--- a/src/main/frontend/app/routes/studio/canvas/nodetypes/components/handle-menu.tsx
+++ b/src/main/frontend/app/routes/studio/canvas/nodetypes/components/handle-menu.tsx
@@ -57,7 +57,7 @@ export default function HandleMenu({
   return createPortal(
     <div
       ref={menuRef}
-      className="nodrag bg-background border-border absolute rounded border shadow-md"
+      className="nodrag bg-background border-border absolute z-5 rounded border shadow-md"
       style={{
         left: `${position.x + 10}px`,
         top: `${position.y - 5}px`,

--- a/src/main/frontend/app/routes/studio/canvas/nodetypes/components/handle.tsx
+++ b/src/main/frontend/app/routes/studio/canvas/nodetypes/components/handle.tsx
@@ -24,10 +24,12 @@ const SEMANTIC_COLOURS: Record<string, string> = {
 const GREEN_BAND_START = 95
 const GREEN_BAND_SIZE = 70
 
+const HASH_MULTIPLIER = 31
+
 function colourFromName(type: string): string {
   let hash = 0
   for (const character of type) {
-    hash = (hash * 31 + (character.codePointAt(0) ?? 0)) % (360 - GREEN_BAND_SIZE)
+    hash = (hash * HASH_MULTIPLIER + (character.codePointAt(0) ?? 0)) % (360 - GREEN_BAND_SIZE)
   }
   const hue = hash < GREEN_BAND_START ? hash : hash + GREEN_BAND_SIZE
   return `hsl(${hue}, 65%, 52%)`

--- a/src/main/frontend/app/routes/studio/canvas/nodetypes/components/handle.tsx
+++ b/src/main/frontend/app/routes/studio/canvas/nodetypes/components/handle.tsx
@@ -21,35 +21,20 @@ const SEMANTIC_COLOURS: Record<string, string> = {
   error: '#ff7605ff',
 }
 
-const FORWARD_COLOURS: Record<string, string> = {
-  notfound: '#1B97D1',
-  empty: '#26A69A',
-  // eslint-disable-next-line unicorn/no-thenable
-  then: '#7E57C2',
-  else: '#EC407A',
-  lessthan: '#5C6BC0',
-  greaterthan: '#00ACC1',
-  equals: '#AB47BC',
-  stop: '#D81B60',
-  continue: '#42A5F5',
-  notinrole: '#8D6E63',
-  custom: '#9575CD',
-}
-
-const FALLBACK_PALETTE = Object.values(FORWARD_COLOURS)
+const GREEN_BAND_START = 95
+const GREEN_BAND_SIZE = 70
 
 function colourFromName(type: string): string {
   let hash = 0
-  for (let index = 0; index < type.length; index++) {
-    hash = (hash * 31 + (type.codePointAt(index) ?? 0)) % FALLBACK_PALETTE.length
+  for (const character of type) {
+    hash = (hash * 31 + (character.codePointAt(0) ?? 0)) % (360 - GREEN_BAND_SIZE)
   }
-  return FALLBACK_PALETTE[hash]
+  const hue = hash < GREEN_BAND_START ? hash : hash + GREEN_BAND_SIZE
+  return `hsl(${hue}, 65%, 52%)`
 }
 
 export function translateHandleTypeToColour(type: string): string {
   const normalized = type.toLowerCase()
-
-  if (normalized in FORWARD_COLOURS) return FORWARD_COLOURS[normalized]
 
   for (const [suffix, colour] of Object.entries(SEMANTIC_COLOURS)) {
     if (normalized.endsWith(suffix)) return colour

--- a/src/main/frontend/app/routes/studio/canvas/nodetypes/components/handle.tsx
+++ b/src/main/frontend/app/routes/studio/canvas/nodetypes/components/handle.tsx
@@ -13,25 +13,49 @@ type HandleProperties = {
   typesAllowed?: Record<string, ElementProperty>
 }
 
-const HANDLE_TYPE_COLOURS: Record<string, string> = {
+const SEMANTIC_COLOURS: Record<string, string> = {
   success: '#68D250',
   failure: '#E84E4E',
   exception: '#424242',
   timeout: '#F2A900',
   error: '#ff7605ff',
-  default: '#1B97D1',
+}
+
+const FORWARD_COLOURS: Record<string, string> = {
+  notfound: '#1B97D1',
+  empty: '#26A69A',
+  // eslint-disable-next-line unicorn/no-thenable
+  then: '#7E57C2',
+  else: '#EC407A',
+  lessthan: '#5C6BC0',
+  greaterthan: '#00ACC1',
+  equals: '#AB47BC',
+  stop: '#D81B60',
+  continue: '#42A5F5',
+  notinrole: '#8D6E63',
+  custom: '#9575CD',
+}
+
+const FALLBACK_PALETTE = Object.values(FORWARD_COLOURS)
+
+function colourFromName(type: string): string {
+  let hash = 0
+  for (let index = 0; index < type.length; index++) {
+    hash = (hash * 31 + (type.codePointAt(index) ?? 0)) % FALLBACK_PALETTE.length
+  }
+  return FALLBACK_PALETTE[hash]
 }
 
 export function translateHandleTypeToColour(type: string): string {
   const normalized = type.toLowerCase()
 
-  for (const [suffix, colour] of Object.entries(HANDLE_TYPE_COLOURS)) {
-    if (normalized.endsWith(suffix)) {
-      return colour
-    }
+  if (normalized in FORWARD_COLOURS) return FORWARD_COLOURS[normalized]
+
+  for (const [suffix, colour] of Object.entries(SEMANTIC_COLOURS)) {
+    if (normalized.endsWith(suffix)) return colour
   }
 
-  return HANDLE_TYPE_COLOURS.default
+  return colourFromName(normalized)
 }
 
 export function CustomHandle(properties: Readonly<HandleProperties>) {

--- a/src/main/frontend/app/routes/studio/canvas/nodetypes/frank-node.tsx
+++ b/src/main/frontend/app/routes/studio/canvas/nodetypes/frank-node.tsx
@@ -64,7 +64,7 @@ export default function FrankNode(properties: NodeProps<FrankNodeType>) {
   const [dragOver, setDragOver] = useState(false)
   const [canDropDraggedElement, setCanDropDraggedElement] = useState(false)
   const showNodeContextMenu = useNodeContextMenu()
-  const { elements, ffDoc } = useFFDoc()
+  const { elements } = useFFDoc()
   const { xsdDoc } = useFrankConfigXsd()
   const {
     setNodeId,
@@ -87,13 +87,13 @@ export default function FrankNode(properties: NodeProps<FrankNodeType>) {
     const recordElements = elements as Record<string, ElementDetails>
 
     const element = Object.values(recordElements).find((element) => element.name === properties.data.subtype) ?? null
-    if (!element || !ffDoc) return element
+    if (!element) return element
 
     return {
       ...element,
-      forwards: resolveForwardsWithInheritance(element.forwards, ffDoc.elements),
+      forwards: resolveForwardsWithInheritance(element.forwards),
     }
-  }, [elements, ffDoc, properties.data.subtype])
+  }, [elements, properties.data.subtype])
 
   const isDeprecated = frankElement?.deprecated
   const [showDeprecated, setShowDeprecated] = useState(false)

--- a/src/main/frontend/app/routes/studio/canvas/nodetypes/frank-node.tsx
+++ b/src/main/frontend/app/routes/studio/canvas/nodetypes/frank-node.tsx
@@ -91,7 +91,7 @@ export default function FrankNode(properties: NodeProps<FrankNodeType>) {
 
     return {
       ...element,
-      forwards: resolveForwardsWithInheritance(element.forwards),
+      forwards: resolveForwardsWithInheritance(element),
     }
   }, [elements, properties.data.subtype])
 

--- a/src/main/frontend/app/routes/studio/canvas/nodetypes/frank-node.tsx
+++ b/src/main/frontend/app/routes/studio/canvas/nodetypes/frank-node.tsx
@@ -27,6 +27,7 @@ import type { ElementDetails } from '@frankframework/doc-library-core'
 import { DeprecatedPopover } from './components/deprecated-popover'
 import { showWarningToast } from '~/components/toast'
 import { useHandleTypes } from '~/hooks/use-handle-types'
+import { resolveForwardsWithInheritance } from '~/utils/frankdoc-utils'
 import AddSubcomponentModal from '~/components/flow/add-subcomponent-modal'
 import { useFrankConfigXsd } from '~/providers/frankconfig-xsd-provider'
 import {
@@ -63,7 +64,7 @@ export default function FrankNode(properties: NodeProps<FrankNodeType>) {
   const [dragOver, setDragOver] = useState(false)
   const [canDropDraggedElement, setCanDropDraggedElement] = useState(false)
   const showNodeContextMenu = useNodeContextMenu()
-  const { elements } = useFFDoc()
+  const { elements, ffDoc } = useFFDoc()
   const { xsdDoc } = useFrankConfigXsd()
   const {
     setNodeId,
@@ -85,8 +86,14 @@ export default function FrankNode(properties: NodeProps<FrankNodeType>) {
     if (!elements) return null
     const recordElements = elements as Record<string, ElementDetails>
 
-    return Object.values(recordElements).find((element) => element.name === properties.data.subtype) ?? null
-  }, [elements, properties.data.subtype])
+    const element = Object.values(recordElements).find((element) => element.name === properties.data.subtype) ?? null
+    if (!element || !ffDoc) return element
+
+    return {
+      ...element,
+      forwards: resolveForwardsWithInheritance(element.forwards, ffDoc.elements),
+    }
+  }, [elements, ffDoc, properties.data.subtype])
 
   const isDeprecated = frankElement?.deprecated
   const [showDeprecated, setShowDeprecated] = useState(false)

--- a/src/main/frontend/app/routes/studio/canvas/nodetypes/frank-node.tsx
+++ b/src/main/frontend/app/routes/studio/canvas/nodetypes/frank-node.tsx
@@ -64,7 +64,7 @@ export default function FrankNode(properties: NodeProps<FrankNodeType>) {
   const [dragOver, setDragOver] = useState(false)
   const [canDropDraggedElement, setCanDropDraggedElement] = useState(false)
   const showNodeContextMenu = useNodeContextMenu()
-  const { elements } = useFFDoc()
+  const { elements, ffDoc } = useFFDoc()
   const { xsdDoc } = useFrankConfigXsd()
   const {
     setNodeId,
@@ -91,9 +91,9 @@ export default function FrankNode(properties: NodeProps<FrankNodeType>) {
 
     return {
       ...element,
-      forwards: resolveForwardsWithInheritance(element),
+      forwards: resolveForwardsWithInheritance(element, ffDoc?.elements, ffDoc?.enums),
     }
-  }, [elements, properties.data.subtype])
+  }, [elements, ffDoc, properties.data.subtype])
 
   const isDeprecated = frankElement?.deprecated
   const [showDeprecated, setShowDeprecated] = useState(false)

--- a/src/main/frontend/app/routes/studio/xml-to-json-parser.spec.ts
+++ b/src/main/frontend/app/routes/studio/xml-to-json-parser.spec.ts
@@ -1,0 +1,75 @@
+import { extractSourceHandles, type ResolveForwards } from './xml-to-json-parser'
+import type { ElementProperty } from '@frankframework/doc-library-core'
+
+function elementFromXml(xml: string): Element {
+  const document_ = new DOMParser().parseFromString(xml, 'text/xml')
+  return document_.documentElement
+}
+
+const FORWARDS: Record<string, Record<string, ElementProperty>> = {
+  EchoPipe: { success: {}, exception: {} },
+  IfPipe: { exception: {}, '*': {}, else: {} },
+  SwitchPipe: { exception: {}, notFound: {}, empty: {}, '*': {} },
+}
+
+const resolveForwards: ResolveForwards = (subtype) => FORWARDS[subtype]
+
+describe('extractSourceHandles', () => {
+  it('creates a handle per <forward> for any element type', () => {
+    const element = elementFromXml(
+      '<IfPipe name="x"><forward name="exception" path="" /><forward name="then" path="" /><forward name="else" path="" /></IfPipe>',
+    )
+    expect(extractSourceHandles(element, resolveForwards)).toEqual([
+      { type: 'exception', index: 1 },
+      { type: 'then', index: 2 },
+      { type: 'else', index: 3 },
+    ])
+  })
+
+  it('does NOT add an implicit success handle to a routing pipe (IfPipe)', () => {
+    const element = elementFromXml(
+      '<IfPipe name="x"><forward name="exception" path="" /><forward name="then" path="" /><forward name="else" path="" /></IfPipe>',
+    )
+    const handles = extractSourceHandles(element, resolveForwards)
+    expect(handles.some((handle) => handle.type === 'success')).toBe(false)
+  })
+
+  it('adds the implicit success fall-through handle for a FixedForwardPipe subclass with only an exception forward', () => {
+    const element = elementFromXml('<EchoPipe name="x"><forward name="exception" path="" /></EchoPipe>')
+    expect(extractSourceHandles(element, resolveForwards)).toEqual([
+      { type: 'exception', index: 1 },
+      { type: 'success', index: 2 },
+    ])
+  })
+
+  it('keeps an explicit success forward without duplicating it', () => {
+    const element = elementFromXml('<EchoPipe name="x"><forward name="success" path="" /></EchoPipe>')
+    expect(extractSourceHandles(element, resolveForwards)).toEqual([{ type: 'success', index: 1 }])
+  })
+
+  it('uses the FrankDoc default handle when no forwards are declared (EchoPipe -> success)', () => {
+    const element = elementFromXml('<EchoPipe name="x" />')
+    expect(extractSourceHandles(element, resolveForwards)).toEqual([{ type: 'success', index: 1 }])
+  })
+
+  it('uses the FrankDoc default handle when no forwards are declared (SwitchPipe -> first routing forward)', () => {
+    const element = elementFromXml('<SwitchPipe name="x" />')
+    expect(extractSourceHandles(element, resolveForwards)).toEqual([{ type: 'notFound', index: 1 }])
+  })
+
+  it('falls back to a single success handle when no FrankDoc resolver is provided', () => {
+    const element = elementFromXml('<SwitchPipe name="x" />')
+    expect(extractSourceHandles(element)).toEqual([{ type: 'success', index: 1 }])
+  })
+
+  it('keeps adding the implicit success handle without a resolver (legacy behaviour)', () => {
+    const element = elementFromXml(
+      '<IfPipe name="x"><forward name="then" path="" /><forward name="else" path="" /></IfPipe>',
+    )
+    expect(extractSourceHandles(element)).toEqual([
+      { type: 'then', index: 1 },
+      { type: 'else', index: 2 },
+      { type: 'success', index: 3 },
+    ])
+  })
+})

--- a/src/main/frontend/app/routes/studio/xml-to-json-parser.ts
+++ b/src/main/frontend/app/routes/studio/xml-to-json-parser.ts
@@ -108,7 +108,8 @@ export type ResolveForwards = (subtype: string) => Record<string, ElementPropert
 
 function supportsSuccessForward(subtype: string, resolveForwards?: ResolveForwards): boolean {
   const forwards = resolveForwards?.(subtype)
-  return forwards ? 'success' in forwards : true
+  if (!forwards || Object.keys(forwards).length === 0) return true
+  return 'success' in forwards
 }
 
 export async function convertAdapterXmlToJson(adapter: Element, resolveForwards?: ResolveForwards) {
@@ -467,7 +468,8 @@ export function extractSourceHandles(element: Element, resolveForwards?: Resolve
   if (forwardElements.length === 0) {
     forwardElements = [...element.querySelectorAll('forward')]
     if (forwardElements.length === 0) {
-      return forwards ? getDefaultSourceHandles(forwards) : [{ type: 'success', index: 1 }]
+      const hasForwards = forwards && Object.keys(forwards).length > 0
+      return hasForwards ? getDefaultSourceHandles(forwards) : [{ type: 'success', index: 1 }]
     }
   }
 

--- a/src/main/frontend/app/routes/studio/xml-to-json-parser.ts
+++ b/src/main/frontend/app/routes/studio/xml-to-json-parser.ts
@@ -5,6 +5,8 @@ import type { FrankNodeType } from '~/routes/studio/canvas/nodetypes/frank-node'
 import { getElementTypeFromName } from '~/routes/studio/node-translator-module'
 import { fetchConfigurationFileCached } from '~/services/configuration-file-service'
 import { translateElementFromOldToNewFormat } from '~/utils/flow-utils'
+import { getDefaultSourceHandles } from '~/utils/frankdoc-utils'
+import type { ElementProperty } from '@frankframework/doc-library-core'
 import { FlowConfig } from './canvas/flow.config'
 import type { GroupNode } from './canvas/nodetypes/group-node'
 import { isFrankNode } from '~/stores/flow-store'
@@ -102,15 +104,22 @@ export async function getAdapterListenerType(
   return null
 }
 
-export async function convertAdapterXmlToJson(adapter: Element) {
+export type ResolveForwards = (subtype: string) => Record<string, ElementProperty> | undefined
+
+function supportsSuccessForward(subtype: string, resolveForwards?: ResolveForwards): boolean {
+  const forwards = resolveForwards?.(subtype)
+  return forwards ? 'success' in forwards : true
+}
+
+export async function convertAdapterXmlToJson(adapter: Element, resolveForwards?: ResolveForwards) {
   const idCounter: IdCounter = { current: 0 }
-  const { nodes: flowNodes, elementToId } = convertAdapterToFlowNodes(adapter, idCounter)
+  const { nodes: flowNodes, elementToId } = convertAdapterToFlowNodes(adapter, idCounter, resolveForwards)
   const stickyNotes = extractStickyNotesFromAdapter(adapter, idCounter, flowNodes)
   const groupNodes = extractGroupNodesFromAdapter(adapter, flowNodes, idCounter)
   assignParentRelationships(flowNodes, groupNodes)
   const allNodes: FlowNode[] = [...groupNodes, ...flowNodes, ...stickyNotes]
 
-  return { nodes: allNodes, edges: extractEdgesFromAdapter(adapter, flowNodes, elementToId) }
+  return { nodes: allNodes, edges: extractEdgesFromAdapter(adapter, flowNodes, elementToId, resolveForwards) }
 }
 
 function buildNodeNameToIdMap(nodes: FlowNode[]): Map<string, string> {
@@ -174,7 +183,12 @@ function buildNameToNodeMap(nodes: FlowNode[]): Map<string, FlowNode> {
  * @param elementToId A mapping of XML Elements to their corresponding node IDs, used for edge creation
  * @returns An array of FrankEdge objects representing all generated edges
  */
-function extractEdgesFromAdapter(adapter: Element, nodes: FlowNode[], elementToId: Map<Element, string>): FrankEdge[] {
+function extractEdgesFromAdapter(
+  adapter: Element,
+  nodes: FlowNode[],
+  elementToId: Map<Element, string>,
+  resolveForwards?: ResolveForwards,
+): FrankEdge[] {
   const pipelineElement = [...adapter.children].find((el) => el.tagName.toLowerCase() === 'pipeline') || null
 
   if (!pipelineElement) return []
@@ -207,9 +221,10 @@ function extractEdgesFromAdapter(adapter: Element, nodes: FlowNode[], elementToI
     explicitTargetsBySourceId,
     sourcesWithSuccessExitForward,
     sourcesWithSuccessPipeForward,
+    resolveForwards,
   )
 
-  addImplicitSuccessExitEdge(nodes, edges, forwardIndexBySourceId)
+  addImplicitSuccessExitEdge(nodes, edges, forwardIndexBySourceId, resolveForwards)
 
   return edges
 }
@@ -347,6 +362,7 @@ function addSequentialFallbackEdges(
   explicitTargetsBySourceId: Map<string, Set<string>>,
   sourcesWithSuccessExitForward: Set<string>,
   sourcesWithSuccessPipeForward: Set<string>,
+  resolveForwards?: ResolveForwards,
 ) {
   for (let i = 0; i < nodes.length - 1; i++) {
     const current = nodes[i]
@@ -354,6 +370,7 @@ function addSequentialFallbackEdges(
     if (current.type === 'exitNode') continue
     // skip receivers (they already get edges to first pipeline pipe)
     if (isFrankNode(current) && current.data.type === 'receiver') continue
+    if (isFrankNode(current) && !supportsSuccessForward(current.data.subtype, resolveForwards)) continue
 
     // find next NON-exit node
     const next = nodes.slice(i + 1).find((n) => n.type !== 'exitNode')
@@ -385,6 +402,7 @@ function addImplicitSuccessExitEdge(
   nodes: FlowNode[],
   edges: FrankEdge[],
   forwardIndexBySourceId: Map<string, number>,
+  resolveForwards?: ResolveForwards,
 ) {
   const successExit = findSuccessExit(nodes)
   if (!successExit) return
@@ -396,6 +414,8 @@ function addImplicitSuccessExitEdge(
   const lastPipelineNode = nodes.toReversed().find((node) => node.type !== 'exitNode')
 
   if (!lastPipelineNode) return
+
+  if (isFrankNode(lastPipelineNode) && !supportsSuccessForward(lastPipelineNode.data.subtype, resolveForwards)) return
 
   const handleIndex = forwardIndexBySourceId.get(lastPipelineNode.id) ?? 1
   forwardIndexBySourceId.set(lastPipelineNode.id, handleIndex + 1)
@@ -438,15 +458,16 @@ function collectPipelineElements(adapter: Element): Element[] {
   return elements
 }
 
-function extractSourceHandles(element: Element): SourceHandle[] {
+export function extractSourceHandles(element: Element, resolveForwards?: ResolveForwards): SourceHandle[] {
+  const { subtype } = translateElementFromOldToNewFormat(element)
+  const forwards = resolveForwards?.(subtype)
+
   let forwardElements = [...element.querySelectorAll('Forward')]
 
-  // Check if forwards are lower case instead
   if (forwardElements.length === 0) {
     forwardElements = [...element.querySelectorAll('forward')]
-    // No forwards? Create a single implicit success handle
     if (forwardElements.length === 0) {
-      return [{ type: 'success', index: 1 }]
+      return forwards ? getDefaultSourceHandles(forwards) : [{ type: 'success', index: 1 }]
     }
   }
 
@@ -459,18 +480,10 @@ function extractSourceHandles(element: Element): SourceHandle[] {
     }
   })
 
-  // Check if any forward represents SUCCESS
-  const hasSuccessForward = forwardElements.some((forward) => {
-    const name = forward.getAttribute('name')?.toUpperCase()
-    return name === 'SUCCESS'
-  })
+  const hasSuccessForward = forwardElements.some((forward) => forward.getAttribute('name')?.toUpperCase() === 'SUCCESS')
 
-  // If not, add implicit fallback handle
-  if (!hasSuccessForward) {
-    handles.push({
-      type: 'success',
-      index: handles.length + 1,
-    })
+  if (!hasSuccessForward && supportsSuccessForward(subtype, resolveForwards)) {
+    handles.push({ type: 'success', index: handles.length + 1 })
   }
 
   return handles
@@ -505,6 +518,7 @@ function processExitElements(element: Element, exitNodes: ExitNode[]) {
 function convertAdapterToFlowNodes(
   adapter: Element,
   idCounter: IdCounter,
+  resolveForwards?: ResolveForwards,
 ): { nodes: FlowNode[]; elementToId: Map<Element, string> } {
   const nodes: FlowNode[] = []
   const exitNodes: ExitNode[] = []
@@ -540,7 +554,7 @@ function convertAdapterToFlowNodes(
       continue
     }
 
-    const sourceHandles = extractSourceHandles(element)
+    const sourceHandles = extractSourceHandles(element, resolveForwards)
     const frankNode: FrankNodeType = convertElementToNode(element, idCounter, sourceHandles)
     elementToId.set(element, frankNode.id)
     nodes.push(frankNode)

--- a/src/main/frontend/app/utils/frankdoc-utils.spec.ts
+++ b/src/main/frontend/app/utils/frankdoc-utils.spec.ts
@@ -1,46 +1,86 @@
 import { getDefaultSourceHandles, resolveForwardsWithInheritance } from './frankdoc-utils'
-import type { ElementProperty } from '@frankframework/doc-library-core'
+import type { ElementClass, ElementProperty } from '@frankframework/doc-library-core'
+
+const FIXED_FORWARD_PIPE_FQN = 'org.frankframework.pipes.FixedForwardPipe'
+const ABSTRACT_PIPE_FQN = 'org.frankframework.pipes.AbstractPipe'
+
+const TEST_ELEMENTS: Record<string, ElementClass> = {
+  [ABSTRACT_PIPE_FQN]: {
+    name: 'AbstractPipe',
+    abstract: true,
+    forwards: { exception: { description: 'error occurred' } },
+  },
+  [FIXED_FORWARD_PIPE_FQN]: {
+    name: 'FixedForwardPipe',
+    abstract: true,
+    parent: ABSTRACT_PIPE_FQN,
+    forwards: { success: { description: 'successful processing' } },
+  },
+}
+
+function echoPipe(overrides: Partial<ElementClass> = {}): ElementClass {
+  return { name: 'EchoPipe', parent: FIXED_FORWARD_PIPE_FQN, ...overrides }
+}
 
 describe('resolveForwardsWithInheritance', () => {
-  it('adds success for a non-router pipe with only an exception forward (e.g. EchoPipe)', () => {
-    const result = resolveForwardsWithInheritance({ forwards: { exception: {} } })
+  it('inherits success for a non-router pipe via the parent chain (e.g. EchoPipe)', () => {
+    const result = resolveForwardsWithInheritance(echoPipe({ forwards: { exception: {} } }), TEST_ELEMENTS)
     expect(result).toHaveProperty('success')
     expect(result).toHaveProperty('exception')
   })
 
-  it('adds success for a non-router pipe without any forwards', () => {
-    expect(resolveForwardsWithInheritance({})).toHaveProperty('success')
+  it('inherits success for a non-router pipe with no own forwards', () => {
+    const result = resolveForwardsWithInheritance(echoPipe(), TEST_ELEMENTS)
+    expect(result).toHaveProperty('success')
   })
 
-  it('adds success when the element is missing', () => {
-    expect(resolveForwardsWithInheritance()).toHaveProperty('success')
+  it('returns empty forwards when the element is missing', () => {
+    expect(resolveForwardsWithInheritance()).toEqual({})
   })
 
-  it('adds success for an endpoint pipe with error forwards (e.g. SenderPipe)', () => {
-    const result = resolveForwardsWithInheritance({
-      forwards: { exception: {}, timeout: {}, '*': {} },
-      labels: { EIP: 'Endpoint' },
-    })
+  it('returns only own forwards when no elements map is provided (no inheritance)', () => {
+    const result = resolveForwardsWithInheritance(echoPipe({ forwards: { exception: {} } }))
+    expect(result).not.toHaveProperty('success')
+    expect(result).toHaveProperty('exception')
+  })
+
+  it('inherits success for an endpoint pipe with error forwards (e.g. SenderPipe)', () => {
+    const result = resolveForwardsWithInheritance(
+      echoPipe({ forwards: { exception: {}, timeout: {}, '*': {} }, labels: { EIP: 'Endpoint' } }),
+      TEST_ELEMENTS,
+    )
     expect(result).toHaveProperty('success')
     expect(result).toHaveProperty('timeout')
   })
 
-  it('does NOT add success for a router pipe (EIP=Router, e.g. SwitchPipe)', () => {
-    const result = resolveForwardsWithInheritance({
-      forwards: { exception: {}, notFound: {}, empty: {}, '*': {} },
-      labels: { EIP: 'Router' },
-    })
+  it('does NOT include success for a router pipe (EIP=Router, e.g. SwitchPipe)', () => {
+    const result = resolveForwardsWithInheritance(
+      echoPipe({ forwards: { exception: {}, notFound: {}, empty: {}, '*': {} }, labels: { EIP: 'Router' } }),
+      TEST_ELEMENTS,
+    )
     expect(result).not.toHaveProperty('success')
   })
 
-  it('does NOT add success for a wildcard-only router (e.g. CounterSwitchPipe)', () => {
-    const result = resolveForwardsWithInheritance({ forwards: { exception: {}, '*': {} }, labels: { EIP: 'Router' } })
+  it('does NOT include success for a wildcard-only router (e.g. CounterSwitchPipe)', () => {
+    const result = resolveForwardsWithInheritance(
+      echoPipe({ forwards: { exception: {}, '*': {} }, labels: { EIP: 'Router' } }),
+      TEST_ELEMENTS,
+    )
     expect(result).not.toHaveProperty('success')
   })
 
-  it('does not duplicate success when the element already defines it', () => {
-    const result = resolveForwardsWithInheritance({ forwards: { exception: {}, success: {} } })
+  it('does not duplicate success when the element already defines it as an own forward', () => {
+    const result = resolveForwardsWithInheritance(echoPipe({ forwards: { exception: {}, success: {} } }), TEST_ELEMENTS)
     expect(Object.keys(result).filter((forward) => forward === 'success')).toHaveLength(1)
+  })
+
+  it('own forwards take precedence over inherited forwards', () => {
+    const ownDesc = 'custom description'
+    const result = resolveForwardsWithInheritance(
+      echoPipe({ forwards: { success: { description: ownDesc } } }),
+      TEST_ELEMENTS,
+    )
+    expect(result.success?.description).toBe(ownDesc)
   })
 })
 
@@ -77,16 +117,16 @@ describe('getDefaultSourceHandles', () => {
   })
 
   it('is consistent with resolveForwardsWithInheritance: a non-router pipe defaults to success', () => {
-    expect(getDefaultSourceHandles(resolveForwardsWithInheritance({ forwards: { exception: {} } }))).toEqual([
-      { type: 'success', index: 1 },
-    ])
+    expect(
+      getDefaultSourceHandles(resolveForwardsWithInheritance(echoPipe({ forwards: { exception: {} } }), TEST_ELEMENTS)),
+    ).toEqual([{ type: 'success', index: 1 }])
   })
 
   it('is consistent with resolveForwardsWithInheritance: a router pipe defaults to its first forward', () => {
-    const resolved = resolveForwardsWithInheritance({
-      forwards: { exception: {}, notFound: {}, empty: {}, '*': {} },
-      labels: { EIP: 'Router' },
-    })
+    const resolved = resolveForwardsWithInheritance(
+      echoPipe({ forwards: { exception: {}, notFound: {}, empty: {}, '*': {} }, labels: { EIP: 'Router' } }),
+      TEST_ELEMENTS,
+    )
     expect(getDefaultSourceHandles(resolved)).toEqual([{ type: 'notFound', index: 1 }])
   })
 })

--- a/src/main/frontend/app/utils/frankdoc-utils.spec.ts
+++ b/src/main/frontend/app/utils/frankdoc-utils.spec.ts
@@ -1,0 +1,127 @@
+// @vitest-environment node
+import { getDefaultSourceHandles, resolveForwardsWithInheritance } from './frankdoc-utils'
+import type { ElementProperty, FFDocJson } from '@frankframework/doc-library-core'
+
+const FIXED_FORWARD_PIPE_CLASS = 'org.frankframework.pipes.FixedForwardPipe'
+
+function makeRawElements(extras: Record<string, object> = {}): FFDocJson['elements'] {
+  return {
+    [FIXED_FORWARD_PIPE_CLASS]: {
+      name: 'FixedForwardPipe',
+      abstract: true,
+      forwards: { success: { description: 'successful processing' } },
+    },
+    ...extras,
+  } as FFDocJson['elements']
+}
+
+describe('resolveForwardsWithInheritance', () => {
+  it('adds success from FixedForwardPipe for a regular pipe with only exception (e.g. EchoPipe)', () => {
+    const result = resolveForwardsWithInheritance({ exception: {} }, makeRawElements())
+    expect(result).toHaveProperty('success')
+    expect(result).toHaveProperty('exception')
+  })
+
+  it('adds success when element has no forwards at all', () => {
+    const result = resolveForwardsWithInheritance({}, makeRawElements())
+    expect(result).toHaveProperty('success')
+  })
+
+  it('adds success when forwards is undefined', () => {
+    const result = resolveForwardsWithInheritance(undefined, makeRawElements())
+    expect(result).toHaveProperty('success')
+  })
+
+  it('does NOT add success for SwitchPipe-style pipes (has empty forward)', () => {
+    const result = resolveForwardsWithInheritance(
+      { exception: {}, notFound: {}, empty: {}, '*': {} },
+      makeRawElements(),
+    )
+    expect(result).not.toHaveProperty('success')
+  })
+
+  it('does NOT add success for IfPipe-style pipes (has then/else forwards)', () => {
+    // eslint-disable-next-line unicorn/no-thenable -- 'then' is a Frank forward name here, not a thenable
+    const result = resolveForwardsWithInheritance({ exception: {}, then: {}, else: {}, '*': {} }, makeRawElements())
+    expect(result).not.toHaveProperty('success')
+  })
+
+  it('does NOT add success for CompareStringPipe (has lessthan/greaterthan/equals)', () => {
+    const result = resolveForwardsWithInheritance(
+      { exception: {}, lessthan: {}, greaterthan: {}, equals: {} },
+      makeRawElements(),
+    )
+    expect(result).not.toHaveProperty('success')
+  })
+
+  it('does NOT add success for ForPipe (has stop/continue)', () => {
+    const result = resolveForwardsWithInheritance({ exception: {}, stop: {}, continue: {} }, makeRawElements())
+    expect(result).not.toHaveProperty('success')
+  })
+
+  it('adds success for SenderPipe-style pipes (error forwards but no routing outcomes)', () => {
+    const result = resolveForwardsWithInheritance(
+      { exception: {}, timeout: {}, illegalResult: {}, '*': {} },
+      makeRawElements(),
+    )
+    expect(result).toHaveProperty('success')
+    expect(result).toHaveProperty('timeout')
+  })
+
+  it('does not duplicate success when element already defines it', () => {
+    const result = resolveForwardsWithInheritance({ exception: {}, success: {} }, makeRawElements())
+    expect(Object.keys(result).filter((k) => k === 'success')).toHaveLength(1)
+  })
+
+  it('returns forwards unchanged when FixedForwardPipe is not in rawElements', () => {
+    const result = resolveForwardsWithInheritance({ exception: {} }, {})
+    expect(result).toEqual({ exception: {} })
+    expect(result).not.toHaveProperty('success')
+  })
+})
+
+describe('getDefaultSourceHandles', () => {
+  it('defaults to the success handle when the element supports the success forward', () => {
+    expect(getDefaultSourceHandles({ success: {}, exception: {} })).toEqual([{ type: 'success', index: 1 }])
+  })
+
+  it('skips the exception error forward when picking the default handle', () => {
+    expect(getDefaultSourceHandles({ exception: {}, success: {} })).toEqual([{ type: 'success', index: 1 }])
+  })
+
+  it('defaults to the first routing forward for switch pipes (no success forward)', () => {
+    expect(getDefaultSourceHandles({ exception: {}, notFound: {}, empty: {}, '*': {} })).toEqual([
+      { type: 'notFound', index: 1 },
+    ])
+  })
+
+  it('maps a wildcard-only forward to a custom default handle', () => {
+    expect(getDefaultSourceHandles({ exception: {}, '*': {} })).toEqual([{ type: 'custom', index: 1 }])
+  })
+
+  it('falls back to exception when it is the only forward', () => {
+    expect(getDefaultSourceHandles({ exception: {} })).toEqual([{ type: 'exception', index: 1 }])
+  })
+
+  it('returns no handles when forwards is empty', () => {
+    expect(getDefaultSourceHandles({})).toEqual([])
+  })
+
+  it('returns no handles when forwards is missing', () => {
+    const missing: Record<string, ElementProperty> | undefined = undefined
+    expect(getDefaultSourceHandles(missing)).toEqual([])
+  })
+
+  it('is consistent with resolveForwardsWithInheritance: a regular pipe defaults to success', () => {
+    const resolved = resolveForwardsWithInheritance({ exception: {} }, makeRawElements())
+    expect(getDefaultSourceHandles(resolved)).toEqual([{ type: 'success', index: 1 }])
+  })
+
+  it('is consistent with resolveForwardsWithInheritance: a SwitchPipe defaults to its first forward', () => {
+    const resolved = resolveForwardsWithInheritance(
+      { exception: {}, notFound: {}, empty: {}, '*': {} },
+      makeRawElements(),
+    )
+    expect(getDefaultSourceHandles(resolved)).toEqual([{ type: 'notFound', index: 1 }])
+  })
+})

--- a/src/main/frontend/app/utils/frankdoc-utils.spec.ts
+++ b/src/main/frontend/app/utils/frankdoc-utils.spec.ts
@@ -1,4 +1,3 @@
-// @vitest-environment node
 import { getDefaultSourceHandles, resolveForwardsWithInheritance } from './frankdoc-utils'
 import type { ElementProperty } from '@frankframework/doc-library-core'
 

--- a/src/main/frontend/app/utils/frankdoc-utils.spec.ts
+++ b/src/main/frontend/app/utils/frankdoc-utils.spec.ts
@@ -1,82 +1,53 @@
 // @vitest-environment node
 import { getDefaultSourceHandles, resolveForwardsWithInheritance } from './frankdoc-utils'
-import type { ElementProperty, FFDocJson } from '@frankframework/doc-library-core'
-
-const FIXED_FORWARD_PIPE_CLASS = 'org.frankframework.pipes.FixedForwardPipe'
-
-function makeRawElements(extras: Record<string, object> = {}): FFDocJson['elements'] {
-  return {
-    [FIXED_FORWARD_PIPE_CLASS]: {
-      name: 'FixedForwardPipe',
-      abstract: true,
-      forwards: { success: { description: 'successful processing' } },
-    },
-    ...extras,
-  } as FFDocJson['elements']
-}
+import type { ElementProperty } from '@frankframework/doc-library-core'
 
 describe('resolveForwardsWithInheritance', () => {
-  it('adds success from FixedForwardPipe for a regular pipe with only exception (e.g. EchoPipe)', () => {
-    const result = resolveForwardsWithInheritance({ exception: {} }, makeRawElements())
+  it('adds success for a regular pipe with only an exception forward (e.g. EchoPipe)', () => {
+    const result = resolveForwardsWithInheritance({ exception: {} })
     expect(result).toHaveProperty('success')
     expect(result).toHaveProperty('exception')
   })
 
-  it('adds success when element has no forwards at all', () => {
-    const result = resolveForwardsWithInheritance({}, makeRawElements())
-    expect(result).toHaveProperty('success')
+  it('adds success when there are no forwards', () => {
+    expect(resolveForwardsWithInheritance({})).toHaveProperty('success')
   })
 
-  it('adds success when forwards is undefined', () => {
-    const result = resolveForwardsWithInheritance(undefined, makeRawElements())
+  it('adds success when forwards is missing', () => {
+    const missing: Record<string, ElementProperty> | undefined = undefined
+    expect(resolveForwardsWithInheritance(missing)).toHaveProperty('success')
+  })
+
+  it('adds success for SenderPipe-style pipes (error forwards but no routing outcomes)', () => {
+    const result = resolveForwardsWithInheritance({ exception: {}, timeout: {}, illegalResult: {}, '*': {} })
     expect(result).toHaveProperty('success')
+    expect(result).toHaveProperty('timeout')
   })
 
   it('does NOT add success for SwitchPipe-style pipes (has empty forward)', () => {
-    const result = resolveForwardsWithInheritance(
-      { exception: {}, notFound: {}, empty: {}, '*': {} },
-      makeRawElements(),
-    )
+    const result = resolveForwardsWithInheritance({ exception: {}, notFound: {}, empty: {}, '*': {} })
     expect(result).not.toHaveProperty('success')
   })
 
   it('does NOT add success for IfPipe-style pipes (has then/else forwards)', () => {
     // eslint-disable-next-line unicorn/no-thenable -- 'then' is a Frank forward name here, not a thenable
-    const result = resolveForwardsWithInheritance({ exception: {}, then: {}, else: {}, '*': {} }, makeRawElements())
+    const result = resolveForwardsWithInheritance({ exception: {}, then: {}, else: {}, '*': {} })
     expect(result).not.toHaveProperty('success')
   })
 
   it('does NOT add success for CompareStringPipe (has lessthan/greaterthan/equals)', () => {
-    const result = resolveForwardsWithInheritance(
-      { exception: {}, lessthan: {}, greaterthan: {}, equals: {} },
-      makeRawElements(),
-    )
+    const result = resolveForwardsWithInheritance({ exception: {}, lessthan: {}, greaterthan: {}, equals: {} })
     expect(result).not.toHaveProperty('success')
   })
 
   it('does NOT add success for ForPipe (has stop/continue)', () => {
-    const result = resolveForwardsWithInheritance({ exception: {}, stop: {}, continue: {} }, makeRawElements())
+    const result = resolveForwardsWithInheritance({ exception: {}, stop: {}, continue: {} })
     expect(result).not.toHaveProperty('success')
   })
 
-  it('adds success for SenderPipe-style pipes (error forwards but no routing outcomes)', () => {
-    const result = resolveForwardsWithInheritance(
-      { exception: {}, timeout: {}, illegalResult: {}, '*': {} },
-      makeRawElements(),
-    )
-    expect(result).toHaveProperty('success')
-    expect(result).toHaveProperty('timeout')
-  })
-
-  it('does not duplicate success when element already defines it', () => {
-    const result = resolveForwardsWithInheritance({ exception: {}, success: {} }, makeRawElements())
-    expect(Object.keys(result).filter((k) => k === 'success')).toHaveLength(1)
-  })
-
-  it('returns forwards unchanged when FixedForwardPipe is not in rawElements', () => {
-    const result = resolveForwardsWithInheritance({ exception: {} }, {})
-    expect(result).toEqual({ exception: {} })
-    expect(result).not.toHaveProperty('success')
+  it('does not duplicate success when the element already defines it', () => {
+    const result = resolveForwardsWithInheritance({ exception: {}, success: {} })
+    expect(Object.keys(result).filter((forward) => forward === 'success')).toHaveLength(1)
   })
 })
 
@@ -113,15 +84,13 @@ describe('getDefaultSourceHandles', () => {
   })
 
   it('is consistent with resolveForwardsWithInheritance: a regular pipe defaults to success', () => {
-    const resolved = resolveForwardsWithInheritance({ exception: {} }, makeRawElements())
-    expect(getDefaultSourceHandles(resolved)).toEqual([{ type: 'success', index: 1 }])
+    expect(getDefaultSourceHandles(resolveForwardsWithInheritance({ exception: {} }))).toEqual([
+      { type: 'success', index: 1 },
+    ])
   })
 
   it('is consistent with resolveForwardsWithInheritance: a SwitchPipe defaults to its first forward', () => {
-    const resolved = resolveForwardsWithInheritance(
-      { exception: {}, notFound: {}, empty: {}, '*': {} },
-      makeRawElements(),
-    )
+    const resolved = resolveForwardsWithInheritance({ exception: {}, notFound: {}, empty: {}, '*': {} })
     expect(getDefaultSourceHandles(resolved)).toEqual([{ type: 'notFound', index: 1 }])
   })
 })

--- a/src/main/frontend/app/utils/frankdoc-utils.spec.ts
+++ b/src/main/frontend/app/utils/frankdoc-utils.spec.ts
@@ -3,50 +3,44 @@ import { getDefaultSourceHandles, resolveForwardsWithInheritance } from './frank
 import type { ElementProperty } from '@frankframework/doc-library-core'
 
 describe('resolveForwardsWithInheritance', () => {
-  it('adds success for a regular pipe with only an exception forward (e.g. EchoPipe)', () => {
-    const result = resolveForwardsWithInheritance({ exception: {} })
+  it('adds success for a non-router pipe with only an exception forward (e.g. EchoPipe)', () => {
+    const result = resolveForwardsWithInheritance({ forwards: { exception: {} } })
     expect(result).toHaveProperty('success')
     expect(result).toHaveProperty('exception')
   })
 
-  it('adds success when there are no forwards', () => {
+  it('adds success for a non-router pipe without any forwards', () => {
     expect(resolveForwardsWithInheritance({})).toHaveProperty('success')
   })
 
-  it('adds success when forwards is missing', () => {
-    const missing: Record<string, ElementProperty> | undefined = undefined
-    expect(resolveForwardsWithInheritance(missing)).toHaveProperty('success')
+  it('adds success when the element is missing', () => {
+    expect(resolveForwardsWithInheritance()).toHaveProperty('success')
   })
 
-  it('adds success for SenderPipe-style pipes (error forwards but no routing outcomes)', () => {
-    const result = resolveForwardsWithInheritance({ exception: {}, timeout: {}, illegalResult: {}, '*': {} })
+  it('adds success for an endpoint pipe with error forwards (e.g. SenderPipe)', () => {
+    const result = resolveForwardsWithInheritance({
+      forwards: { exception: {}, timeout: {}, '*': {} },
+      labels: { EIP: 'Endpoint' },
+    })
     expect(result).toHaveProperty('success')
     expect(result).toHaveProperty('timeout')
   })
 
-  it('does NOT add success for SwitchPipe-style pipes (has empty forward)', () => {
-    const result = resolveForwardsWithInheritance({ exception: {}, notFound: {}, empty: {}, '*': {} })
+  it('does NOT add success for a router pipe (EIP=Router, e.g. SwitchPipe)', () => {
+    const result = resolveForwardsWithInheritance({
+      forwards: { exception: {}, notFound: {}, empty: {}, '*': {} },
+      labels: { EIP: 'Router' },
+    })
     expect(result).not.toHaveProperty('success')
   })
 
-  it('does NOT add success for IfPipe-style pipes (has then/else forwards)', () => {
-    // eslint-disable-next-line unicorn/no-thenable -- 'then' is a Frank forward name here, not a thenable
-    const result = resolveForwardsWithInheritance({ exception: {}, then: {}, else: {}, '*': {} })
-    expect(result).not.toHaveProperty('success')
-  })
-
-  it('does NOT add success for CompareStringPipe (has lessthan/greaterthan/equals)', () => {
-    const result = resolveForwardsWithInheritance({ exception: {}, lessthan: {}, greaterthan: {}, equals: {} })
-    expect(result).not.toHaveProperty('success')
-  })
-
-  it('does NOT add success for ForPipe (has stop/continue)', () => {
-    const result = resolveForwardsWithInheritance({ exception: {}, stop: {}, continue: {} })
+  it('does NOT add success for a wildcard-only router (e.g. CounterSwitchPipe)', () => {
+    const result = resolveForwardsWithInheritance({ forwards: { exception: {}, '*': {} }, labels: { EIP: 'Router' } })
     expect(result).not.toHaveProperty('success')
   })
 
   it('does not duplicate success when the element already defines it', () => {
-    const result = resolveForwardsWithInheritance({ exception: {}, success: {} })
+    const result = resolveForwardsWithInheritance({ forwards: { exception: {}, success: {} } })
     expect(Object.keys(result).filter((forward) => forward === 'success')).toHaveLength(1)
   })
 })
@@ -83,14 +77,17 @@ describe('getDefaultSourceHandles', () => {
     expect(getDefaultSourceHandles(missing)).toEqual([])
   })
 
-  it('is consistent with resolveForwardsWithInheritance: a regular pipe defaults to success', () => {
-    expect(getDefaultSourceHandles(resolveForwardsWithInheritance({ exception: {} }))).toEqual([
+  it('is consistent with resolveForwardsWithInheritance: a non-router pipe defaults to success', () => {
+    expect(getDefaultSourceHandles(resolveForwardsWithInheritance({ forwards: { exception: {} } }))).toEqual([
       { type: 'success', index: 1 },
     ])
   })
 
-  it('is consistent with resolveForwardsWithInheritance: a SwitchPipe defaults to its first forward', () => {
-    const resolved = resolveForwardsWithInheritance({ exception: {}, notFound: {}, empty: {}, '*': {} })
+  it('is consistent with resolveForwardsWithInheritance: a router pipe defaults to its first forward', () => {
+    const resolved = resolveForwardsWithInheritance({
+      forwards: { exception: {}, notFound: {}, empty: {}, '*': {} },
+      labels: { EIP: 'Router' },
+    })
     expect(getDefaultSourceHandles(resolved)).toEqual([{ type: 'notFound', index: 1 }])
   })
 })

--- a/src/main/frontend/app/utils/frankdoc-utils.ts
+++ b/src/main/frontend/app/utils/frankdoc-utils.ts
@@ -1,31 +1,24 @@
 import type { ElementProperty } from '@frankframework/doc-library-core'
 import { getHandleTypes } from '~/hooks/use-handle-types'
 
-const ROUTING_OUTCOME_FORWARDS = new Set([
-  'then',
-  'else',
-  'lessthan',
-  'greaterthan',
-  'equals',
-  'stop',
-  'continue',
-  'empty',
-])
-
 export interface SourceHandle {
   type: string
   index: number
 }
 
+interface ForwardSource {
+  forwards?: Record<string, ElementProperty>
+  labels?: Record<string, string>
+}
+
 export function resolveForwardsWithInheritance(
-  forwards: Record<string, ElementProperty> | undefined,
+  element: ForwardSource | null | undefined,
 ): Record<string, ElementProperty> {
-  const resolved = forwards ?? {}
+  const forwards = element?.forwards ?? {}
 
-  const isRoutingPipe = Object.keys(resolved).some((forward) => ROUTING_OUTCOME_FORWARDS.has(forward))
-  if (isRoutingPipe) return resolved
+  if (element?.labels?.EIP === 'Router') return forwards
 
-  return { success: {}, ...resolved }
+  return { success: {}, ...forwards }
 }
 
 export function getDefaultSourceHandles(resolvedForwards: Record<string, ElementProperty> | undefined): SourceHandle[] {

--- a/src/main/frontend/app/utils/frankdoc-utils.ts
+++ b/src/main/frontend/app/utils/frankdoc-utils.ts
@@ -1,7 +1,5 @@
-import type { ElementProperty, FFDocJson } from '@frankframework/doc-library-core'
+import type { ElementProperty } from '@frankframework/doc-library-core'
 import { getHandleTypes } from '~/hooks/use-handle-types'
-
-const FIXED_FORWARD_PIPE_CLASS = 'org.frankframework.pipes.FixedForwardPipe'
 
 const ROUTING_OUTCOME_FORWARDS = new Set([
   'then',
@@ -20,18 +18,14 @@ export interface SourceHandle {
 }
 
 export function resolveForwardsWithInheritance(
-  effectiveForwards: Record<string, ElementProperty> | undefined,
-  rawElements: FFDocJson['elements'],
+  forwards: Record<string, ElementProperty> | undefined,
 ): Record<string, ElementProperty> {
-  const forwards = effectiveForwards ?? {}
+  const resolved = forwards ?? {}
 
-  const fixedForwardPipe = rawElements[FIXED_FORWARD_PIPE_CLASS]
-  if (!fixedForwardPipe?.forwards) return forwards
+  const isRoutingPipe = Object.keys(resolved).some((forward) => ROUTING_OUTCOME_FORWARDS.has(forward))
+  if (isRoutingPipe) return resolved
 
-  const isRoutingPipe = Object.keys(forwards).some((forward) => ROUTING_OUTCOME_FORWARDS.has(forward))
-  if (isRoutingPipe) return forwards
-
-  return { ...fixedForwardPipe.forwards, ...forwards }
+  return { success: {}, ...resolved }
 }
 
 export function getDefaultSourceHandles(resolvedForwards: Record<string, ElementProperty> | undefined): SourceHandle[] {

--- a/src/main/frontend/app/utils/frankdoc-utils.ts
+++ b/src/main/frontend/app/utils/frankdoc-utils.ts
@@ -2,12 +2,12 @@ import { getInheritedProperties } from '@frankframework/doc-library-core'
 import type { ElementClass, ElementProperty, EnumValue } from '@frankframework/doc-library-core'
 import { getHandleTypes } from '~/hooks/use-handle-types'
 
-export interface SourceHandle {
+export type SourceHandle = {
   type: string
   index: number
 }
 
-interface ForwardSource {
+type ForwardSource = {
   forwards?: Record<string, ElementProperty>
   labels?: Record<string, string>
   parent?: string

--- a/src/main/frontend/app/utils/frankdoc-utils.ts
+++ b/src/main/frontend/app/utils/frankdoc-utils.ts
@@ -1,0 +1,43 @@
+import type { ElementProperty, FFDocJson } from '@frankframework/doc-library-core'
+import { getHandleTypes } from '~/hooks/use-handle-types'
+
+const FIXED_FORWARD_PIPE_CLASS = 'org.frankframework.pipes.FixedForwardPipe'
+
+const ROUTING_OUTCOME_FORWARDS = new Set([
+  'then',
+  'else',
+  'lessthan',
+  'greaterthan',
+  'equals',
+  'stop',
+  'continue',
+  'empty',
+])
+
+export interface SourceHandle {
+  type: string
+  index: number
+}
+
+export function resolveForwardsWithInheritance(
+  effectiveForwards: Record<string, ElementProperty> | undefined,
+  rawElements: FFDocJson['elements'],
+): Record<string, ElementProperty> {
+  const forwards = effectiveForwards ?? {}
+
+  const fixedForwardPipe = rawElements[FIXED_FORWARD_PIPE_CLASS]
+  if (!fixedForwardPipe?.forwards) return forwards
+
+  const isRoutingPipe = Object.keys(forwards).some((forward) => ROUTING_OUTCOME_FORWARDS.has(forward))
+  if (isRoutingPipe) return forwards
+
+  return { ...fixedForwardPipe.forwards, ...forwards }
+}
+
+export function getDefaultSourceHandles(resolvedForwards: Record<string, ElementProperty> | undefined): SourceHandle[] {
+  const handleTypes = getHandleTypes(resolvedForwards)
+  if (handleTypes.length === 0) return []
+
+  const defaultType = handleTypes.find((type) => type !== 'exception') ?? handleTypes[0]
+  return [{ type: defaultType, index: 1 }]
+}

--- a/src/main/frontend/app/utils/frankdoc-utils.ts
+++ b/src/main/frontend/app/utils/frankdoc-utils.ts
@@ -1,4 +1,5 @@
-import type { ElementProperty } from '@frankframework/doc-library-core'
+import { getInheritedProperties } from '@frankframework/doc-library-core'
+import type { ElementClass, ElementProperty, EnumValue } from '@frankframework/doc-library-core'
 import { getHandleTypes } from '~/hooks/use-handle-types'
 
 export interface SourceHandle {
@@ -9,19 +10,35 @@ export interface SourceHandle {
 interface ForwardSource {
   forwards?: Record<string, ElementProperty>
   labels?: Record<string, string>
+  parent?: string
 }
 
 export function resolveForwardsWithInheritance(
   element: ForwardSource | null | undefined,
+  allElements?: Record<string, ElementClass>,
+  enums?: Record<string, Record<string, EnumValue>>,
 ): Record<string, ElementProperty> {
-  const forwards = element?.forwards ?? {}
+  if (!element) return {}
 
-  if (element?.labels?.EIP === 'Router') return forwards
+  const ownForwards = element.forwards ?? {}
 
-  return { success: {}, ...forwards }
+  const inherited =
+    allElements && element.parent
+      ? getInheritedProperties(element as ElementClass, allElements, enums ?? {}).forwards
+      : {}
+
+  const merged = { ...inherited, ...ownForwards }
+
+  const isRouter = element.labels?.EIP === 'Router'
+  if (isRouter) {
+    const { success: _omit, ...withoutSuccess } = merged
+    return withoutSuccess
+  }
+
+  return merged
 }
 
-export function getDefaultSourceHandles(resolvedForwards: Record<string, ElementProperty> | undefined): SourceHandle[] {
+export function getDefaultSourceHandles(resolvedForwards?: Record<string, ElementProperty>): SourceHandle[] {
   const handleTypes = getHandleTypes(resolvedForwards)
   if (handleTypes.length === 0) return []
 

--- a/src/main/frontend/vitest.config.ts
+++ b/src/main/frontend/vitest.config.ts
@@ -1,9 +1,19 @@
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import tsconfigPaths from 'vite-tsconfig-paths'
 
+const docLibrary = (FFPackage: string, entry: string) =>
+  fileURLToPath(new URL(`node_modules/@frankframework/${FFPackage}/${entry}`, import.meta.url))
+
 export default defineConfig({
   plugins: [react(), tsconfigPaths()],
+  resolve: {
+    alias: {
+      '@frankframework/doc-library-core': docLibrary('doc-library-core', 'dist/doc-library-core.js'),
+      '@frankframework/doc-library-react': docLibrary('doc-library-react', 'doc-library-react.js'),
+    },
+  },
   test: {
     globals: true,
     environment: 'jsdom',

--- a/src/main/java/org/frankframework/flow/frankdoc/FrankDocService.java
+++ b/src/main/java/org/frankframework/flow/frankdoc/FrankDocService.java
@@ -1,5 +1,13 @@
 package org.frankframework.flow.frankdoc;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import lombok.extern.log4j.Log4j2;
 import org.frankframework.flow.exception.ApiException;
 import org.springframework.http.HttpStatus;
@@ -13,22 +21,74 @@ public class FrankDocService {
 	private static final String FRANKDOC_JSON_URL = "https://reference.frankframework.org/js/frankdoc.json";
 
 	private final RestTemplate restTemplate;
+	private final ObjectMapper objectMapper;
 
-	public FrankDocService(RestTemplate restTemplate) {
+	public FrankDocService(RestTemplate restTemplate, ObjectMapper objectMapper) {
 		this.restTemplate = restTemplate;
+		this.objectMapper = objectMapper;
 	}
 
 	/**
-	 * Fetches the FrankDoc JSON from the external URL.
+	 * Fetches the FrankDoc JSON and repairs broken parent chains before returning it.
 	 *
-	 * @return The FrankDoc JSON as a String.
+	 * @return Repaired FrankDoc JSON.
 	 */
 	public String getFrankDocJson() {
 		try {
 			log.info("Fetching FrankDoc JSON from {}", FRANKDOC_JSON_URL);
-			return restTemplate.getForObject(FRANKDOC_JSON_URL, String.class);
+			String raw = restTemplate.getForObject(FRANKDOC_JSON_URL, String.class);
+			return repairParentChains(raw);
 		} catch (RestClientException _) {
 			throw new ApiException("Failed to fetch FrankDoc JSON", HttpStatus.NOT_FOUND);
 		}
+	}
+
+	private String repairParentChains(String frankDocJson) {
+		try {
+			JsonNode root = objectMapper.readTree(frankDocJson);
+			JsonNode elements = root.path("elements");
+
+			Map<String, List<String>> childrenByParent = groupChildrenByParent(elements);
+			childrenByParent.forEach((parentFqn, siblings) ->
+					findSuccessDeclaringAbstract(elements, siblings)
+							.ifPresent(successBase -> repointSiblingsToBase(elements, siblings, successBase))
+			);
+
+			return objectMapper.writeValueAsString(root);
+		} catch (Exception e) {
+			log.warn("Failed to repair FrankDoc parent chains, returning raw JSON", e);
+			return frankDocJson;
+		}
+	}
+
+	private static Map<String, List<String>> groupChildrenByParent(JsonNode elements) {
+		Map<String, List<String>> childrenByParent = new HashMap<>();
+		elements.fields().forEachRemaining(entry -> {
+			String parentFqn = entry.getValue().path("parent").asText(null);
+			if (parentFqn != null) {
+				childrenByParent.computeIfAbsent(parentFqn, k -> new ArrayList<>()).add(entry.getKey());
+			}
+		});
+		return childrenByParent;
+	}
+
+	private static Optional<String> findSuccessDeclaringAbstract(JsonNode elements, List<String> siblings) {
+		return siblings.stream()
+				.filter(fqn -> isAbstract(elements.path(fqn)) && declaresSuccessForward(elements.path(fqn)))
+				.findFirst();
+	}
+
+	private static void repointSiblingsToBase(JsonNode elements, List<String> siblings, String successBase) {
+		siblings.stream()
+				.filter(fqn -> !fqn.equals(successBase))
+				.forEach(fqn -> ((ObjectNode) elements.path(fqn)).put("parent", successBase));
+	}
+
+	private static boolean isAbstract(JsonNode element) {
+		return element.path("abstract").asBoolean(false);
+	}
+
+	private static boolean declaresSuccessForward(JsonNode element) {
+		return element.path("forwards").has("success");
 	}
 }

--- a/src/main/java/org/frankframework/flow/frankdoc/FrankDocService.java
+++ b/src/main/java/org/frankframework/flow/frankdoc/FrankDocService.java
@@ -3,11 +3,11 @@ package org.frankframework.flow.frankdoc;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import lombok.extern.log4j.Log4j2;
 import org.frankframework.flow.exception.ApiException;
 import org.springframework.http.HttpStatus;
@@ -49,7 +49,7 @@ public class FrankDocService {
 			JsonNode elements = root.path("elements");
 
 			Map<String, List<String>> childrenByParent = groupChildrenByParent(elements);
-			childrenByParent.forEach((parentFqn, siblings) ->
+			childrenByParent.values().forEach(siblings ->
 					findSuccessDeclaringAbstract(elements, siblings)
 							.ifPresent(successBase -> repointSiblingsToBase(elements, siblings, successBase))
 			);
@@ -62,26 +62,24 @@ public class FrankDocService {
 	}
 
 	private static Map<String, List<String>> groupChildrenByParent(JsonNode elements) {
-		Map<String, List<String>> childrenByParent = new HashMap<>();
-		elements.fields().forEachRemaining(entry -> {
-			String parentFqn = entry.getValue().path("parent").asText(null);
-			if (parentFqn != null) {
-				childrenByParent.computeIfAbsent(parentFqn, k -> new ArrayList<>()).add(entry.getKey());
-			}
-		});
-		return childrenByParent;
+		Iterable<Map.Entry<String, JsonNode>> fields = elements::fields;
+		return StreamSupport.stream(fields.spliterator(), false)
+				.filter(entry -> entry.getValue().hasNonNull("parent"))
+				.collect(Collectors.groupingBy(
+						entry -> entry.getValue().get("parent").asText(),
+						Collectors.mapping(Map.Entry::getKey, Collectors.toList())));
 	}
 
 	private static Optional<String> findSuccessDeclaringAbstract(JsonNode elements, List<String> siblings) {
 		return siblings.stream()
-				.filter(fqn -> isAbstract(elements.path(fqn)) && declaresSuccessForward(elements.path(fqn)))
+				.filter(fullyQualifiedName -> isAbstract(elements.path(fullyQualifiedName)) && declaresSuccessForward(elements.path(fullyQualifiedName)))
 				.findFirst();
 	}
 
 	private static void repointSiblingsToBase(JsonNode elements, List<String> siblings, String successBase) {
 		siblings.stream()
-				.filter(fqn -> !fqn.equals(successBase))
-				.forEach(fqn -> ((ObjectNode) elements.path(fqn)).put("parent", successBase));
+				.filter(fullyQualifiedName -> !fullyQualifiedName.equals(successBase))
+				.forEach(fullyQualifiedName -> ((ObjectNode) elements.path(fullyQualifiedName)).put("parent", successBase));
 	}
 
 	private static boolean isAbstract(JsonNode element) {

--- a/src/test/java/org/frankframework/flow/frankdoc/FrankDocServiceTest.java
+++ b/src/test/java/org/frankframework/flow/frankdoc/FrankDocServiceTest.java
@@ -3,6 +3,8 @@ package org.frankframework.flow.frankdoc;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.frankframework.flow.exception.ApiException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,13 +20,16 @@ class FrankDocServiceTest {
 	@Mock
 	private RestTemplate restTemplate;
 
+	@Mock
+	private ObjectMapper objectMapper;
+
 	private FrankDocService frankDocService;
 
 	private static final String FRANKDOC_URL = "https://reference.frankframework.org/js/frankdoc.json";
 
 	@BeforeEach
 	void setUp() {
-		frankDocService = new FrankDocService(restTemplate);
+		frankDocService = new FrankDocService(restTemplate, objectMapper);
 	}
 
 	@Test

--- a/src/test/java/org/frankframework/flow/frankdoc/FrankDocServiceTest.java
+++ b/src/test/java/org/frankframework/flow/frankdoc/FrankDocServiceTest.java
@@ -37,8 +37,8 @@ class FrankDocServiceTest {
 		return objectMapper.readTree(result);
 	}
 
-	private static String parentOf(JsonNode root, String elementFqn) {
-		return root.path("elements").path(elementFqn).path("parent").asText(null);
+	private static String parentOf(JsonNode root, String elementFullyQualifiedName) {
+		return root.path("elements").path(elementFullyQualifiedName).path("parent").asText(null);
 	}
 
 	@Test

--- a/src/test/java/org/frankframework/flow/frankdoc/FrankDocServiceTest.java
+++ b/src/test/java/org/frankframework/flow/frankdoc/FrankDocServiceTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.frankframework.flow.exception.ApiException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/frankframework/flow/frankdoc/FrankDocServiceTest.java
+++ b/src/test/java/org/frankframework/flow/frankdoc/FrankDocServiceTest.java
@@ -3,6 +3,7 @@ package org.frankframework.flow.frankdoc;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.frankframework.flow.exception.ApiException;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,8 +20,7 @@ class FrankDocServiceTest {
 	@Mock
 	private RestTemplate restTemplate;
 
-	@Mock
-	private ObjectMapper objectMapper;
+	private final ObjectMapper objectMapper = new ObjectMapper();
 
 	private FrankDocService frankDocService;
 
@@ -31,8 +31,18 @@ class FrankDocServiceTest {
 		frankDocService = new FrankDocService(restTemplate, objectMapper);
 	}
 
+	private JsonNode fetchAndParse(String rawJson) throws Exception {
+		when(restTemplate.getForObject(FRANKDOC_URL, String.class)).thenReturn(rawJson);
+		String result = frankDocService.getFrankDocJson();
+		return objectMapper.readTree(result);
+	}
+
+	private static String parentOf(JsonNode root, String elementFqn) {
+		return root.path("elements").path(elementFqn).path("parent").asText(null);
+	}
+
 	@Test
-	void getFrankDocJsonReturnsJsonContent() {
+	void getFrankDocJsonReturnsContentWhenThereIsNothingToRepair() {
 		String expectedJson = "{\"version\":\"1.0\",\"types\":{}}";
 		when(restTemplate.getForObject(FRANKDOC_URL, String.class)).thenReturn(expectedJson);
 
@@ -49,5 +59,113 @@ class FrankDocServiceTest {
 		assertThrows(ApiException.class, () -> frankDocService.getFrankDocJson());
 
 		verify(restTemplate).getForObject(FRANKDOC_URL, String.class);
+	}
+
+	@Test
+	void repointsSiblingsToTheAbstractSuccessDeclaringSibling() throws Exception {
+		String json = """
+				{
+				"elements": {
+					"org.frankframework.core.IPipe": {},
+					"org.frankframework.pipes.AbstractPipe": {
+					"parent": "org.frankframework.core.IPipe",
+					"abstract": true,
+					"forwards": { "success": "the pipe that is executed next" }
+					},
+					"org.frankframework.pipes.EchoPipe": {
+					"parent": "org.frankframework.core.IPipe"
+					},
+					"org.frankframework.pipes.XmlSwitch": {
+					"parent": "org.frankframework.core.IPipe"
+					}
+				}
+				}
+				""";
+
+		JsonNode root = fetchAndParse(json);
+
+		assertEquals("org.frankframework.pipes.AbstractPipe", parentOf(root, "org.frankframework.pipes.EchoPipe"));
+		assertEquals("org.frankframework.pipes.AbstractPipe", parentOf(root, "org.frankframework.pipes.XmlSwitch"));
+		assertEquals("org.frankframework.core.IPipe", parentOf(root, "org.frankframework.pipes.AbstractPipe"));
+	}
+
+	@Test
+	void leavesParentsUntouchedWhenNoSiblingIsBothAbstractAndDeclaresSuccess() throws Exception {
+		String json = """
+				{
+				"elements": {
+					"P": {},
+					"AbstractWithoutSuccess": { "parent": "P", "abstract": true },
+					"ConcreteWithSuccess": { "parent": "P", "forwards": { "success": "next" } }
+				}
+				}
+				""";
+
+		JsonNode root = fetchAndParse(json);
+
+		assertEquals("P", parentOf(root, "AbstractWithoutSuccess"));
+		assertEquals("P", parentOf(root, "ConcreteWithSuccess"));
+	}
+
+	@Test
+	void repairsEachParentGroupIndependently() throws Exception {
+		String json = """
+				{
+				"elements": {
+					"IPipe": {},
+					"ISender": {},
+					"AbstractPipe": {
+					"parent": "IPipe",
+					"abstract": true,
+					"forwards": { "success": "next" }
+					},
+					"EchoPipe": { "parent": "IPipe" },
+					"AbstractSender": {
+					"parent": "ISender",
+					"abstract": true,
+					"forwards": { "success": "next" }
+					},
+					"HttpSender": { "parent": "ISender" }
+				}
+				}
+				""";
+
+		JsonNode root = fetchAndParse(json);
+
+		assertEquals("AbstractPipe", parentOf(root, "EchoPipe"));
+		assertEquals("AbstractSender", parentOf(root, "HttpSender"));
+		assertEquals("IPipe", parentOf(root, "AbstractPipe"));
+		assertEquals("ISender", parentOf(root, "AbstractSender"));
+	}
+
+	@Test
+	void ignoresElementsWithoutAParent() throws Exception {
+		String json = """
+				{
+				"elements": {
+					"Root": { "abstract": true, "forwards": { "success": "next" } },
+					"AbstractPipe": {
+					"parent": "Root",
+					"abstract": true,
+					"forwards": { "success": "next" }
+					}
+				}
+				}
+				""";
+
+		JsonNode root = fetchAndParse(json);
+
+		assertNull(parentOf(root, "Root"));
+		assertEquals("Root", parentOf(root, "AbstractPipe"));
+	}
+
+	@Test
+	void returnsRawJsonWhenContentCannotBeParsed() {
+		String malformed = "{ this is not valid json";
+		when(restTemplate.getForObject(FRANKDOC_URL, String.class)).thenReturn(malformed);
+
+		String result = frankDocService.getFrankDocJson();
+
+		assertEquals(malformed, result);
 	}
 }


### PR DESCRIPTION
Now i have made logic to make different colors for each handle type.
The thing is that we could reuse the colour logic of #536 here as well. But this needs to be merged first
<img width="1221" height="761" alt="image" src="https://github.com/user-attachments/assets/e21638d3-2a54-4f78-9d4b-9d7a6729adef" />
<img width="795" height="451" alt="image" src="https://github.com/user-attachments/assets/db1db5ab-c4f9-45e2-a954-787bea701f6f" />
